### PR TITLE
Fix unable to resize browser viewport

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -33,6 +33,9 @@ async function newPage(config, chrome_args=[]) {
     const params = {
         args,
         ignoreHTTPSErrors: (config.env === 'local'),
+        // By default puppeteer emulates the browser's viewport which breaks resizing the browser window.
+        // See: https://github.com/puppeteer/puppeteer/issues/3688#issuecomment-453218745
+        defaultViewport: null,
     };
     if (!config.headless) {
         params.headless = false;

--- a/runner.js
+++ b/runner.js
@@ -36,11 +36,15 @@ async function run_task(config, task) {
                     async (page, i) => {
                         await promisify(mkdirp)(config.screenshot_directory);
                         const fn = path.join(config.screenshot_directory, `${task.name}-${i}.png`);
-                        return await page.screenshot({
+                        await page.screenshot({
                             path: fn,
                             type: 'png',
                             fullPage: true,
                         });
+
+                        // Taking a screenshot will break viewport resizing. Setting both
+                        // "width" and "height" to 0 will restore resizing capabilities.
+                        await page.setViewport({width: 0, height: 0});
                     }));
             } catch(e) {
                 output.log(config, `INTERNAL ERROR: failed to take screenshot of ${task.name}: ${e}`);


### PR DESCRIPTION
This PR makes the browser's viewport resizeable. Previously the viewport was locked to puppeteer's default `800 x 600px` size.