### PR TITLE
Add screenshot comparison assertion

### DIFF
--- a/assert_screenshots.js
+++ b/assert_screenshots.js
@@ -1,0 +1,91 @@
+const fs = require('fs');
+const {PNG} = require('pngjs');
+const pixelmatch = require('pixelmatch');
+const mkdirpCb = require('mkdirp');
+const {promisify} = require('util');
+const path = require('path');
+const assert = require('assert');
+
+const mkdirp = promisify(mkdirpCb);
+
+/**
+ * Create an image showing the difference between image A and B.
+ * @param {import('pngjs').PNGWithMetadata} a 
+ * @param {import('pngjs').PNGWithMetadata} b 
+ * @returns {{diff_image: import('pngjs').PNG, diff_pixel_count: number}}
+ */
+function create_diff_image(a, b) {
+    // Get max dimensions
+    const width = Math.max(a.width, b.width);
+    const height = Math.max(a.height, b.height);
+
+    const diff = new PNG({width, height});
+    const diff_pixel_count = pixelmatch(
+        a.data,
+        b.data,
+        diff.data,
+        width,
+        height,
+        {threshold: 0.1}
+    );
+
+    return {
+        diff_image: diff,
+        diff_pixel_count
+    };
+}
+
+/**
+ * Take a screenshot of the current page and compare it with the
+ * previous one if any exists.
+ * @param {import('puppeteer').Page} page 
+ * @param {*} config 
+ * @param {string} name 
+ */
+async function assert_screenshot(page, config, name) {
+    assert(name);
+
+    await mkdirp(config.screenshot_directory);
+
+    const actual = path.join(
+        config.screenshot_directory,
+        `${config.task_name}-${name}-actual.png`
+    );
+    const expected = path.join(
+        config.screenshot_directory,
+        `${config.task_name}-${name}-expected.png`
+    );
+
+    const has_expected = fs.existsSync(expected);
+
+    await page.screenshot({
+        fullPage: true,
+        type: 'png',
+        // If no previous screenshot exist we can treat the current
+        // one as the expected screenshot for future assertions.
+        path: has_expected ? actual : expected,
+    });
+
+    // No point in making comparisons when there is nothing to
+    // compare the screenshot to.
+    if (has_expected) {
+        const {diff_image, diff_pixel_count} = create_diff_image(
+            PNG.sync.read(fs.readFileSync(expected)),
+            PNG.sync.read(fs.readFileSync(actual)),
+        );
+        
+        if (diff_pixel_count > 0) {
+            const diff_file = path.join(
+                config.screenshot_directory,
+                `${config.task_name}-${name}-diff.png`
+            );
+            fs.writeFileSync(diff_file, PNG.sync.write(diff_image));
+            
+            throw new Error(`Screenshots do not match. See: ${diff_file}`);
+        }
+    }
+}
+
+module.exports = {
+    assert_screenshot,
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -2776,6 +2776,19 @@
       "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
       "dev": true
     },
+    "pixelmatch": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.1.0.tgz",
+      "integrity": "sha512-HqtgvuWN12tBzKJf7jYsc38Ha28Q2NYpmBL9WostEGgDHJqbTLkjydZXL1ZHM02ZnB+Dkwlxo87HBY38kMiD6A==",
+      "requires": {
+        "pngjs": "^3.4.0"
+      }
+    },
+    "pngjs": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-3.4.0.tgz",
+      "integrity": "sha512-NCrCHhWmnQklfH4MtJMRjZ2a8c80qXeMlQMv2uVp9ISJMTt562SbGd6n2oq0PaPgKm7Z6pL9E2UlLIhC+SHL3w=="
+    },
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "libmime": "^4.0.1",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.3.0",
+    "pixelmatch": "^5.1.0",
+    "pngjs": "^3.4.0",
     "stream-buffers": "^3.0.2",
     "tmp-promise": "^2.0.2"
   },

--- a/runner.js
+++ b/runner.js
@@ -16,7 +16,7 @@ const version = require('./version');
 
 
 async function run_task(config, task) {
-    const task_config = {...config, _browser_pages: []};
+    const task_config = {...config, _browser_pages: [], task_name: task.name};
     try {
         await task.tc.run(task_config);
         task.status = 'success';


### PR DESCRIPTION
One of the recurring issues in the frontend team is that due to the brittle nature of many styling declaration any changes may propagate to unexpected places.

The goal with this PR is to make these unintended effects visible by adding a new `assert_screenshot` function. It captures a screenshot of the current browser page and compares it with a previous screenshot, if one exists. The previous and the current screenshot are compared via a typical image diff algorithm and all differences are highlighted in bright yellow. The generated diff-image makes it easy to see unintended differences in styling.

This PR is not complete yet.

Tasks:

- [x] Add `assert_screenshot`
- [x] Compare current image with previous
- [ ] Ability to update existing screenshots
- [ ] Add tests