### PR TITLE
Add a clean make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,5 +12,8 @@ doc: *.js tsconfig.json
 lockserver-dev:
 	node_modules/.bin/nodemon lockserver/lockserver.js
 
-.PHONY: default lint test lockserver-dev
+clean:
+	@npm run clean
+
+.PHONY: default lint test lockserver-dev clean
 


### PR DESCRIPTION
We already have all the code, but for developers dealing with many different languages and frameworks (like me) it's soothing to be able to rely on `make`.
