### PR TITLE
clean: Remove doc/

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "test": "./run",
     "lint": "eslint . run",
     "types": "tsc",
-    "clean": "rimraf *.d.ts",
+    "clean": "rimraf *.d.ts doc",
     "prepublishOnly": "npm run clean && npm run types"
   },
   "repository": {


### PR DESCRIPTION
The doc directory is 100% generated from source code, therefore not checked in, and hence should be deleted with `make clean`.
