### PR TITLE
Improve doc generation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ test:
 	@npm run test --silent
 
 doc: *.js tsconfig.json
-	./node_modules/.bin/typedoc --out doc --noEmit --excludeNotExported --excludeNotDocumented
+	./node_modules/.bin/typedoc --out doc --noEmit --excludeNotExported --excludeNotDocumented --excludeExternals \
+		browser_utils.js email.js net_utils.js promise_utils.js utils.js
 
 lockserver-dev:
 	node_modules/.bin/nodemon lockserver/lockserver.js


### PR DESCRIPTION
Make our modules show up as major modules instead of externals loaded from `index.js`, and hide all private modules.
