### PR TITLE
Add clickNestedText helper

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -502,7 +502,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=20
                         continue;
                     }
 
-                    if (matchFunc(child.textContent)) {
+                    if (child.childNodes.length > 0 && matchFunc(child.textContent)) {
                         item = child;
                         break;
                     }

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -486,7 +486,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=20
             while (item = stack.pop()) { // eslint-disable-line no-cond-assign
                 // Optimization: If there is only one child we can immediately
                 // continue traversing and skip `.textContent` access.
-                if (item.childNodes.length === 1) {
+                if (item.childNodes.length === 1 && item.childNodes[0].nodeType !== Node.TEXT_NODE) {
                     stack.push(item.childNodes[0]);
                     continue;
                 }

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -494,14 +494,6 @@ async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=20
             let item = document.body;
             let lastFound = null;
             while (true) { // eslint-disable-line no-constant-condition
-                // Optimization: If there is only one child we can immediately
-                // continue traversing and skip `.textContent` access.
-                if (item.childNodes.length === 1 && item.childNodes[0].nodeType !== Node.TEXT_NODE) {
-                    item = item.childNodes[0];
-                    lastFound = item;
-                    continue;
-                }
-
                 for (let i = 0; i < item.childNodes.length; i++) {
                     const child = item.childNodes[i];
                     

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -459,8 +459,11 @@ async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPat
  * 
  * @param {import('puppeteer').Page} page puppeteer page object.
  * @param {string | RegExp} textOrRegExp Text or regex to match the text that the element must contain.
- * @param {{extraMessage?: string}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {{extraMessage?: string, timeout?: number, checkEvery?: number, visible?: boolean}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {number?} timeout How long to wait, in milliseconds.
+ * @param {number?} checkEvery Intervals between checks, in milliseconds. (default: 200ms)
  * @param {string?} extraMessage Optional error message shown if the element is not visible in time.
+ * @param {boolean?} visibale Optional check if element is visible (default: true)
  */
 async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=200, extraMessage=undefined, visible=true}={}) {
     if (typeof textOrRegExp === 'string') {

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -513,7 +513,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=20
                         // the last matched index to ensure we're always starting
                         // our next match from the beginning.
                         matcher.lastIndex = 0;
-                        if (text.match(matcher) !== null) {
+                        if (matcher.test(text)) {
                             item = child;
                             break;
                         }

--- a/tests/selftest_clickNestedText.js
+++ b/tests/selftest_clickNestedText.js
@@ -47,6 +47,18 @@ async function run(config) {
     await clickNestedText(page, /span text/);
     assert.deepStrictEqual(clicks, ['first', 'nested', 'span']);
 
+    // Edge case
+    clicks = [];
+    await page.setContent(`
+        <html>
+            <body>
+                <button onclick="pentfClick('clickme')">clickme</button>
+            </body>
+        </html>
+    `);
+    await clickNestedText(page, 'clickme');
+    assert.deepStrictEqual(clicks, ['clickme']);
+
     await closePage(page);
 }
 

--- a/tests/selftest_clickNestedText.js
+++ b/tests/selftest_clickNestedText.js
@@ -1,0 +1,57 @@
+const assert = require('assert');
+
+const {closePage, newPage, clickNestedText} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    let clicks = [];
+
+    await page.setContent(`
+        <div>
+            <button onclick="pentfClick('first')">first</button>
+            <button onclick="pentfClick('nested')">Some <span>nested <b>text</b></span></button>
+            <div>Some <span onclick="pentfClick('span')">span <b>text</b></span></div>
+            <div data-testid="invisible" style="display:none;" onclick="pentfClick('invisible')">invisible</div>
+        </div>
+    `);
+    await page.exposeFunction('pentfClick', clickId => {
+        clicks.push(clickId);
+    });
+    
+    // String variant
+    await clickNestedText(page, 'first');
+    assert.deepStrictEqual(clicks, ['first']);
+    
+    await clickNestedText(page, 'Some nested text');
+    assert.deepStrictEqual(clicks, ['first', 'nested']);
+
+    clicks = [];
+    await assert.rejects(clickNestedText(page, 'not-present', {timeout: 1, extraMessage: 'blabla'}), {
+        message: 'Unable to find visible text "not-present" after 1ms (blabla)',
+    });
+    assert.deepStrictEqual(clicks, []);
+
+    await assert.rejects(clickNestedText(page, 'invisible', {timeout: 43}), {
+        message: 'Unable to find visible text "invisible" after 43ms',
+    });
+
+    // RegExp variant
+    clicks = [];
+
+    await clickNestedText(page, /first/);
+    assert.deepStrictEqual(clicks, ['first']);
+    
+    await clickNestedText(page, /Some.*text/);
+    assert.deepStrictEqual(clicks, ['first', 'nested']);
+
+    await clickNestedText(page, /span text/);
+    assert.deepStrictEqual(clicks, ['first', 'nested', 'span']);
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'The clickNestedText browser_utils function clicks elements by matching text content',
+    resources: [],
+    run,
+};

--- a/tests/selftest_clickNestedText.js
+++ b/tests/selftest_clickNestedText.js
@@ -9,7 +9,7 @@ async function run(config) {
     await page.setContent(`
         <div>
             <button onclick="pentfClick('first')">first</button>
-            <button onclick="pentfClick('nested')">Some <span>nested <b>text</b></span></button>
+            <button onclick="pentfClick('nested')">Some <span>nested <b>foo</b></span></button>
             <div>Some <span onclick="pentfClick('span')">span <b>text</b></span></div>
             <div data-testid="invisible" style="display:none;" onclick="pentfClick('invisible')">invisible</div>
         </div>
@@ -22,7 +22,7 @@ async function run(config) {
     await clickNestedText(page, 'first');
     assert.deepStrictEqual(clicks, ['first']);
     
-    await clickNestedText(page, 'Some nested text');
+    await clickNestedText(page, 'Some nested foo');
     assert.deepStrictEqual(clicks, ['first', 'nested']);
 
     clicks = [];
@@ -41,7 +41,7 @@ async function run(config) {
     await clickNestedText(page, /first/);
     assert.deepStrictEqual(clicks, ['first']);
     
-    await clickNestedText(page, /Some.*text/);
+    await clickNestedText(page, /Some.*foo/);
     assert.deepStrictEqual(clicks, ['first', 'nested']);
 
     await clickNestedText(page, /span text/);
@@ -58,6 +58,24 @@ async function run(config) {
     `);
     await clickNestedText(page, 'clickme');
     assert.deepStrictEqual(clicks, ['clickme']);
+
+    clicks = [];
+    await page.setContent(`
+        <html>
+            <body>
+                <div>click</div>
+                foo
+                <span>
+                    foo
+                    <button onclick="pentfClick('clickme')">clickme foo</button>
+                </span>
+            </body>
+        </html>
+    `);
+    await clickNestedText(page, /^clickme/);
+    await clickNestedText(page, /foo$/);
+    assert.deepStrictEqual(clicks, ['clickme', 'clickme']);
+
 
     await closePage(page);
 }


### PR DESCRIPTION
~~This PR adds support for nested text nodes with `clickText`. Previously the XPath selector only took direct descended text nodes into account and would ignore nodes wrapped with a `span` or any other element.~~

~~See this comment on SO for an in-depth explanation: https://stackoverflow.com/a/55424335/755391~~

As discussed offline, I've rewritten the PR to add a new helper to match nested text nodes.