### PR TITLE
Fix counts in output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 node_modules
-results.*
+results*.pdf
+results*.html
+results*.md
+results*.json
 screenshots
 doc/
 

--- a/render.js
+++ b/render.js
@@ -2,6 +2,7 @@ const fs = require('fs');
 const {promisify} = require('util');
 const {html2pdf} = require('./browser_utils');
 const {timezoneOffsetString} = require('./utils');
+const {resultCountString} = require('./results');
 
 const utils = require('./utils');
 
@@ -125,10 +126,6 @@ function markdown(results) {
         );
     }).join('\n');
 
-    const success_count = utils.count(results.tests, s => s.status === 'success');
-    const error_count = utils.count(results.tests, s => s.status === 'error');
-    const skipped_count = utils.count(results.tests, s => s.status === 'skipped');
-
     const report_header_md = (
         results.config.report_header_md ? '\n' + results.config.report_header_md + '\n' : '');
 
@@ -140,7 +137,7 @@ Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.
 Start: ${format_timestamp(results.start)}  
 
 ### Results
-Total number of tests: ${results.tests.length} (${success_count} successful, ${error_count} failures, ${skipped_count} skipped)  
+Total number of tests: ${results.tests.length} (${resultCountString(results.tests)})  
 Total test duration: ${format_duration(results.duration)}  
 
 | #     | Test              | Description       | Duration | Result  |
@@ -235,10 +232,6 @@ function html(results) {
 
         return res;
     }).join('\n');
-
-    const success_count = utils.count(results.tests, s => s.status === 'success');
-    const error_count = utils.count(results.tests, s => s.status === 'error');
-    const skipped_count = utils.count(results.tests, s => s.status === 'skipped');
 
     const report_header_html = results.config.report_header_html || '';
 
@@ -350,7 +343,7 @@ Version: ${results.testsVersion}, pentf ${results.pentfVersion}<br/>
 </p>
 
 <h2>Results</h2>
-Total number of tests: ${results.tests.length} (${success_count} successful, ${error_count} failures, ${skipped_count} skipped)<br/>
+Total number of tests: ${results.tests.length} (${resultCountString(results.tests)})<br/>
 Total test duration: ${escape_html(format_duration(results.duration))}<br/>
 
 <table>

--- a/results.js
+++ b/results.js
@@ -1,0 +1,32 @@
+const utils = require('./utils');
+
+/**
+* Summarize test results.
+* @hidden
+* @returns {string} A string with counts of the results.
+**/
+function resultCountString(tasks) {
+    const success = utils.count(tasks, t => t.status === 'success' && !t.expectedToFail);
+    const errored = utils.count(tasks, t => t.status === 'error' && !t.expectedToFail);
+    const skipped = utils.count(tasks, t => t.status === 'skipped');
+    const expectedToFail = utils.count(
+        tasks, t => t.expectedToFail && t.status === 'error');
+    const expectedToFailButPassed = utils.count(
+        tasks, t => t.expectedToFail && t.status === 'success');
+
+    let res = `${success} tests passed, ${errored} failed`;
+    if (skipped) {
+        res += `, ${skipped} skipped`;
+    }
+    if (expectedToFail) {
+        res += `, ${expectedToFail} failed as expected`;
+    }
+    if (expectedToFailButPassed) {
+        res += `, ${expectedToFailButPassed} were expected to fail but passed`;
+    }
+    return res;
+}
+
+module.exports = {
+    resultCountString,
+};

--- a/tests/selftest_resultCountString.js
+++ b/tests/selftest_resultCountString.js
@@ -1,0 +1,33 @@
+const assert = require('assert').strict;
+
+const {resultCountString} = require('../results');
+
+async function run() {
+    const simple = [
+        {status: 'success'},
+        {status: 'success'},
+        {status: 'success'},
+        {status: 'skipped'},
+        {status: 'error'},
+        {status: 'error'},
+    ];
+    assert.strictEqual(
+        resultCountString(simple), '3 tests passed, 2 failed, 1 skipped');
+
+    const everythingOnce = [
+        {status: 'success'},
+        {status: 'skipped'},
+        {status: 'skipped', expectedToFail: 'should count as skipped'},
+        {status: 'error'},
+        {status: 'error', expectedToFail: 'expected error'},
+        {status: 'success', expectedToFail: 'expected error but passed'},
+    ];
+    assert.strictEqual(
+        resultCountString(everythingOnce),
+        '1 tests passed, 1 failed, 2 skipped, 1 failed as expected, 1 were expected to fail but passed');
+}
+
+module.exports = {
+    description: 'Testing pentf itself: counting and classifying test results',
+    run,
+};


### PR DESCRIPTION
Add a test dealing the somewhat obscure cases of `expectedToFail` tests _passing_ and other exotic stuff.
Share the code for the count string generation between the `output` and `render` modules.
