### PR TITLE
Call process.exit after tests are run

### DIFF
--- a/main.js
+++ b/main.js
@@ -76,9 +76,10 @@ async function real_main(options={}) {
     }
 
     await render.doRender(config, results);
-    const any_errors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
-    if (!config.keep_open && any_errors) {
-        process.exit(config.exit_zero ? 0 : 3);
+    if (!config.keep_open) {
+        const anyErrors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
+        const retCode = (!anyErrors || config.exit_zero) ? 0 : 3;
+        process.exit(retCode);
     }
 }
 


### PR DESCRIPTION
Jörn observed some problems with pentf-based tests hanging for a long time.
I originally posited a problem with the teardown, but another theory is that we are leaking some long-running promises in some of the tests that are _not_ torn down.
Fortunately, the workaround/fix for that is very simple: Once tests are done, exit.

In the future, we may add detection of leaked promises / timeouts, but from my cursory rasearch, that may be very complicated.
