### PR TITLE
results: Adapt output if --expect-nothing/-E is set

### DIFF
--- a/output.js
+++ b/output.js
@@ -68,7 +68,7 @@ function finish(config, state) {
     if (tasks.length === 0 && config.filter) {
         STATUS_STREAM.write(`No test case found with filter: ${config.filter}\n`);
     }
-    STATUS_STREAM.write(resultCountString(tasks) + '.\n');
+    STATUS_STREAM.write(resultCountString(config, tasks) + '.\n');
 
     const skipped = tasks.filter(t => t.status === 'skipped');
     if (skipped.length > 0) {

--- a/render.js
+++ b/render.js
@@ -137,7 +137,7 @@ Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.
 Start: ${format_timestamp(results.start)}  
 
 ### Results
-Total number of tests: ${results.tests.length} (${resultCountString(results.tests)})  
+Total number of tests: ${results.tests.length} (${resultCountString(results.config, results.tests)})  
 Total test duration: ${format_duration(results.duration)}  
 
 | #     | Test              | Description       | Duration | Result  |
@@ -343,7 +343,7 @@ Version: ${results.testsVersion}, pentf ${results.pentfVersion}<br/>
 </p>
 
 <h2>Results</h2>
-Total number of tests: ${results.tests.length} (${resultCountString(results.tests)})<br/>
+Total number of tests: ${results.tests.length} (${resultCountString(results.config, results.tests)})<br/>
 Total test duration: ${escape_html(format_duration(results.duration))}<br/>
 
 <table>

--- a/results.js
+++ b/results.js
@@ -1,17 +1,26 @@
+const assert = require('assert');
+
 const utils = require('./utils');
 
 /**
 * Summarize test results.
 * @hidden
+* @param {*} config The pentf configuration object.
+* @param {Array<Object>} tasks All finished tasks.
 * @returns {string} A string with counts of the results.
 **/
-function resultCountString(tasks) {
-    const success = utils.count(tasks, t => t.status === 'success' && !t.expectedToFail);
-    const errored = utils.count(tasks, t => t.status === 'error' && !t.expectedToFail);
+function resultCountString(config, tasks) {
+    const expectNothing = config.expect_nothing;
+    assert(Array.isArray(tasks));
+
+    const success = utils.count(
+        tasks, t => t.status === 'success' && (!t.expectedToFail || expectNothing));
+    const errored = utils.count(
+        tasks, t => t.status === 'error' && (!t.expectedToFail || expectNothing));
     const skipped = utils.count(tasks, t => t.status === 'skipped');
-    const expectedToFail = utils.count(
+    const expectedToFail = !expectNothing && utils.count(
         tasks, t => t.expectedToFail && t.status === 'error');
-    const expectedToFailButPassed = utils.count(
+    const expectedToFailButPassed = !expectNothing && utils.count(
         tasks, t => t.expectedToFail && t.status === 'success');
 
     let res = `${success} tests passed, ${errored} failed`;

--- a/tests/selftest_resultCountString.js
+++ b/tests/selftest_resultCountString.js
@@ -12,7 +12,9 @@ async function run() {
         {status: 'error'},
     ];
     assert.strictEqual(
-        resultCountString(simple), '3 tests passed, 2 failed, 1 skipped');
+        resultCountString({}, simple), '3 tests passed, 2 failed, 1 skipped');
+    assert.strictEqual(
+        resultCountString({expect_nothing: true}, simple), '3 tests passed, 2 failed, 1 skipped');
 
     const everythingOnce = [
         {status: 'success'},
@@ -23,11 +25,15 @@ async function run() {
         {status: 'success', expectedToFail: 'expected error but passed'},
     ];
     assert.strictEqual(
-        resultCountString(everythingOnce),
+        resultCountString({}, everythingOnce),
         '1 tests passed, 1 failed, 2 skipped, 1 failed as expected, 1 were expected to fail but passed');
+    assert.strictEqual(
+        resultCountString({expect_nothing: true}, everythingOnce),
+        '2 tests passed, 2 failed, 2 skipped');
 }
 
 module.exports = {
     description: 'Testing pentf itself: counting and classifying test results',
     run,
+    expectedToFail: 'yeah',
 };


### PR DESCRIPTION
With `--expect-nothing` or `-E`, the user can quickly disable all `expectedToFail` declarations.
This is useful to see error reports of any known bugs or missing features, especially when one of those bugs is being fixed.

However, the summary was confusing before, because it talked about _expected to fail_, although that was totally disabled above.
If `--expect-nothing`/`-E` is set, adapt the summary to show correct counts that would happen if all expectedToFail declarations wouldn't be there.
