### PR TITLE
Add diff of expected and actual value in output

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,12 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@types/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-mIenTfsIe586/yzsyfql69KRnA75S8SVXQbTLpDejRrjH0QSJcpu3AUOi/Vjnt9IOsXKxPhJfGpQUNMueIU1fQ==",
+      "dev": true
+    },
     "@types/events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
@@ -659,6 +665,11 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+    },
+    "diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "doctrine": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "@types/glob": "^7.1.1",
     "@types/puppeteer": "^2.0.1",
     "argparse": "^1.0.10",
+    "diff": "^4.0.2",
     "emailjs-imap-client": "^3.0.7",
     "emailjs-mime-parser": "^2.0.5",
     "form-data": "^2.3.3",
@@ -23,6 +24,7 @@
     "tmp-promise": "^2.0.2"
   },
   "devDependencies": {
+    "@types/diff": "^4.0.2",
     "deep-equal": "^1.0.1",
     "eslint": "^6.2.2",
     "nodemon": "^1.18.11",

--- a/runner.js
+++ b/runner.js
@@ -68,7 +68,7 @@ async function run_task(config, task) {
                     config, `PASSED test case ${task.name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
             } else {
                 output.log(
-                    config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${e.stack}\n`);
+                    config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${output.generateDiff(e)}${e.stack}\n`);
             }
         }
         if (config.fail_fast) {

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -1,0 +1,25 @@
+const assert = require('assert');
+const {generateDiff} = require('../output');
+
+async function run() {
+    try {
+        assert.deepEqual({foo: 123,bar:23}, {bar:23});
+    } catch (err) {
+        assert.equal(
+            generateDiff(err).trim(),
+            [
+                '\n',
+                ' {',
+                '-  "foo": 123,',
+                '   "bar": 23',
+                ' }'
+            ].join('\n').trim()
+        );
+    }
+}
+
+module.exports = {
+    description: 'Check a diff is generated based on the error',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
This PR adds a nice diff output of the actual and expected value of assertions.

Before:

```txt
FAILED test case selftest_diff at 2020-04-29T10:16:30.785+02:00:
AssertionError [ERR_ASSERTION]: { foo: 123, bar: 23 } deepEqual { bar: 23 }
    at Object.run (/Users/m.hagemeister/dev/github/pentf/tests/selftest_diff.js:5:10)
    at run_task (/Users/m.hagemeister/dev/github/pentf/runner.js:22:23)
    at run_one (/Users/m.hagemeister/dev/github/pentf/runner.js:111:11)
    at parallel_run (/Users/m.hagemeister/dev/github/pentf/runner.js:161:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```

After:

```txt
FAILED test case selftest_diff at 2020-04-29T10:15:21.223+02:00:

 {
-  "foo": 123,
   "bar": 23
 }

AssertionError [ERR_ASSERTION]: { foo: 123, bar: 23 } deepEqual { bar: 23 }
    at Object.run (/dev/pentf/tests/selftest_diff.js:5:10)
    at run_task (/dev/pentf/runner.js:22:23)
    at run_one (/dev/pentf/runner.js:111:11)
    at parallel_run (/dev/pentf/runner.js:161:29)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```