### PR TITLE
Colorize cli output

### DIFF
--- a/config.js
+++ b/config.js
@@ -84,6 +84,11 @@ function parseArgs(options) {
         action: 'storeTrue',
         help: 'Ignore expectedToFail attributes on tests',
     });
+    output_group.addArgument(['--no-colors'], {
+        action: 'storeFalse',
+        dest: 'colors',
+        help: 'Disable colors in stdout'
+    });
 
     const results_group = parser.addArgumentGroup({title: 'Writing results to disk'});
     results_group.addArgument(['-J', '--json'], {

--- a/main.js
+++ b/main.js
@@ -17,7 +17,7 @@ const {loadTests} = require('./loader');
 // - rootDir: Root directory (assume tests/ contains tests, config/ if exists contains config)
 // - testsDir: Test directory
 // - configDir: Configuration directory. false disables configuration.
-// - noColors: Disable colors in stdout.
+// - colors: Enable/Disable colors in stdout (default: true).
 async function real_main(options={}) {
     if (options.rootDir) {
         if (! options.testsDir) {
@@ -31,15 +31,17 @@ async function real_main(options={}) {
         }
     }
 
-    if (options.noColors) {
-        kolorist.options.enabled = false;
-    }
 
     const args = parseArgs(options);
     const config = readConfig(options, args);
     if (options.defaultConfig) {
         options.defaultConfig(config);
     }
+
+    if (options.colors === false || !config.colors) {
+        kolorist.options.enabled = false;
+    }
+
     const test_cases = await loadTests(args, options.testsDir, options.testsGlob);
     config._testsDir = options.testsDir;
     if (options.rootDir) config._rootDir = options.rootDir;

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 /*eslint no-console: "off"*/
 
 const fs = require('fs');
+const kolorist = require('kolorist');
 const path = require('path');
 
 const {readConfig, parseArgs} = require('./config');
@@ -16,6 +17,7 @@ const {loadTests} = require('./loader');
 // - rootDir: Root directory (assume tests/ contains tests, config/ if exists contains config)
 // - testsDir: Test directory
 // - configDir: Configuration directory. false disables configuration.
+// - noColors: Disable colors in stdout.
 async function real_main(options={}) {
     if (options.rootDir) {
         if (! options.testsDir) {
@@ -27,6 +29,10 @@ async function real_main(options={}) {
                 options.configDir = autoConfigDir;
             }
         }
+    }
+
+    if (options.noColors) {
+        kolorist.options.enabled = false;
     }
 
     const args = parseArgs(options);

--- a/output.js
+++ b/output.js
@@ -152,22 +152,36 @@ function generateDiff(err) {
     // Remove patch meta block that's not relevant for us
     const lines = patch.split('\n').splice(5);
 
+    const indent = '  ';
     const formatted = lines
         .map(line => {
             if (line[0] === '-') {
-                return kolorist.red(line);
+                return indent + kolorist.red(line);
             } else if (line[0] === '+') {
-                return kolorist.green(line);
+                return indent + kolorist.green(line);
             }
-            return line;
+            return indent + line;
         })
         .join('\n');
 
     return `\n${formatted}\n`;
 }
 
+/**
+ * Format the error 
+ * @param {Error} err Error object to format
+ */
+function formatError(err) {
+    return err.stack
+        .split('\n')
+        // Indent stack trace
+        .map(line => '   ' + line)
+        .join('\n');
+}
+
 module.exports = {
     finish,
+    formatError,
     log,
     logVerbose,
     generateDiff,

--- a/output.js
+++ b/output.js
@@ -3,6 +3,7 @@
 const assert = require('assert');
 const readline = require('readline');
 const diff = require('diff');
+const kolorist = require('kolorist');
 
 const utils = require('./utils');
 const {resultCountString} = require('./results');
@@ -31,7 +32,7 @@ function status(config, state) {
     const done_count = utils.count(tasks, t => (t.status === 'success') || (t.status === 'error'));
     const failed_count = utils.count(tasks, t => t.status === 'error');
     const skipped_count = utils.count(tasks, t => t.status === 'skipped');
-    const failed_str = failed_count > 0 ? `${failed_count} failed, ` : '';
+    const failed_str = failed_count > 0 ? kolorist.red(`${failed_count} failed, `) : '';
 
     // Fit output into one line
     // Instead of listing all running tests  (aaa bbb ccc), we write (aaa  +2).
@@ -151,7 +152,18 @@ function generateDiff(err) {
     // Remove patch meta block that's not relevant for us
     const lines = patch.split('\n').splice(5);
 
-    return `\n${lines.join('\n')}\n`;
+    const formatted = lines
+        .map(line => {
+            if (line[0] === '-') {
+                return kolorist.red(line);
+            } else if (line[0] === '+') {
+                return kolorist.green(line);
+            }
+            return line;
+        })
+        .join('\n');
+
+    return `\n${formatted}\n`;
 }
 
 module.exports = {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2447,6 +2447,12 @@
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "dev": true
     },
+    "kolorist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/kolorist/-/kolorist-1.2.0.tgz",
+      "integrity": "sha512-WMRaf2kYZYllod4vnmpAh1fmtuyqYKsjEA7VsU2kYydtWqq2Vm92oZW2K4y/IczCAYJXQKLTth6/ldc1WCVXhQ==",
+      "dev": true
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/diff": "^4.0.2",
     "deep-equal": "^1.0.1",
     "eslint": "^6.2.2",
+    "kolorist": "^1.2.0",
     "nodemon": "^1.18.11",
     "puppeteer": "^2.1.1",
     "rimraf": "^3.0.2",

--- a/run
+++ b/run
@@ -16,4 +16,5 @@ pentf.main({
         config.report_header_md = 'This is the end-to-end test report in *markdown* form.';
         config.report_header_html = 'This is the end-to-end test report in <strong>HTML/PDF</strong> form.';
     },
+    noColors: true
 });

--- a/run
+++ b/run
@@ -16,5 +16,5 @@ pentf.main({
         config.report_header_md = 'This is the end-to-end test report in *markdown* form.';
         config.report_header_html = 'This is the end-to-end test report in <strong>HTML/PDF</strong> form.';
     },
-    noColors: true
+    colors: false
 });

--- a/runner.js
+++ b/runner.js
@@ -5,6 +5,7 @@ const path = require('path');
 const {performance} = require('perf_hooks');
 const {promisify} = require('util');
 const mkdirp = require('mkdirp');
+const kolorist = require('kolorist');
 
 const browser_utils = require('./browser_utils');
 const email = require('./email');
@@ -24,7 +25,8 @@ async function run_task(config, task) {
         task.duration = performance.now() - task.start;
         if (task.expectedToFail && !config.expect_nothing) {
             const etf = (typeof task.expectedToFail === 'string') ? ` (${task.expectedToFail})` : '';
-            output.log(config, `PASSED test case ${task.name}, but expectedToFail was set${etf}\n`);
+            const label = kolorist.inverse(kolorist.red(' PASSED '));
+            output.log(config, `${label} test case ${kolorist.lightCyan(task.name)}, but expectedToFail was set${etf}\n`);
         }
     } catch(e) {
         task.status = 'error';
@@ -63,12 +65,15 @@ async function run_task(config, task) {
             !(config.ignore_errors && (new RegExp(config.ignore_errors)).test(e.stack)) &&
             (config.expect_nothing || !task.expectedToFail));
         if (show_error) {
+            const name = kolorist.lightCyan(task.name);
             if (e.pentf_expectedToSucceed) {
+                const label = kolorist.inverse(kolorist.green(' PASSED '));
                 output.log(
-                    config, `PASSED test case ${task.name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
+                    config, `${label} test case ${name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
             } else {
+                const label = kolorist.inverse(kolorist.red(' FAILED '));
                 output.log(
-                    config, `FAILED test case ${task.name} at ${utils.localIso8601()}:\n${output.generateDiff(e)}${e.stack}\n`);
+                    config, `${label} test case ${name} at ${utils.localIso8601()}:\n${output.generateDiff(e)}${e.stack}\n`);
             }
         }
         if (config.fail_fast) {

--- a/runner.js
+++ b/runner.js
@@ -73,7 +73,7 @@ async function run_task(config, task) {
             } else {
                 const label = kolorist.inverse(kolorist.red(' FAILED '));
                 output.log(
-                    config, `${label} test case ${name} at ${utils.localIso8601()}:\n${output.generateDiff(e)}${e.stack}\n`);
+                    config, `${label} test case ${name} at ${utils.localIso8601()}:\n${output.generateDiff(e)}${output.formatError(e)}\n`);
             }
         }
         if (config.fail_fast) {

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const kolorist = require('kolorist');
 
 const runner = require('../runner');
 
@@ -10,7 +9,7 @@ async function run() {
         concurrency: 0,
         quiet: true,
         env: 'totallybroken',
-        logFunc: (_config, msg) => output.push(kolorist.stripColors(msg)),
+        logFunc: (_config, msg) => output.push(msg),
     };
 
     const testCases = [{

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const kolorist = require('kolorist');
 
 const runner = require('../runner');
 
@@ -9,7 +10,7 @@ async function run() {
         concurrency: 0,
         quiet: true,
         env: 'totallybroken',
-        logFunc: (_config, msg) => output.push(msg),
+        logFunc: (_config, msg) => output.push(kolorist.stripColors(msg)),
     };
 
     const testCases = [{
@@ -42,18 +43,18 @@ async function run() {
 
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_success')));
-    assert(output.some(o => o.includes('FAILED test case normal_failure')));
-    assert(! output.some(o => o.includes('FAILED test case expected_failure_true')));
-    assert(! output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
-    assert(output.some(o => o.includes('PASSED test case unexpected_success')));
+    assert(output.some(o => o.includes(' FAILED  test case normal_failure')));
+    assert(! output.some(o => o.includes(' FAILED  test case expected_failure_true')));
+    assert(! output.some(o => o.includes(' FAILED  test case works_except_on_totallybroken')));
+    assert(output.some(o => o.includes(' PASSED  test case unexpected_success')));
     assert(! output.some(o => o.includes('test case expected_success')));
 
     output = [];
     runnerConfig.expect_nothing = true;
     await runner.run(runnerConfig, testCases);
-    assert(output.some(o => o.includes('FAILED test case normal_failure')));
-    assert(output.some(o => o.includes('FAILED test case expected_failure_true')));
-    assert(output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
+    assert(output.some(o => o.includes(' FAILED  test case normal_failure')));
+    assert(output.some(o => o.includes(' FAILED  test case expected_failure_true')));
+    assert(output.some(o => o.includes(' FAILED  test case works_except_on_totallybroken')));
 }
 
 module.exports = {

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const kolorist = require('kolorist');
 
 const runner = require('../runner');
 const {expectedToFail} = require('../promise_utils');
@@ -10,7 +11,7 @@ async function run() {
         concurrency: 0,
         quiet: true,
         env: 'totallybroken',
-        logFunc: (_config, msg) => output.push(msg),
+        logFunc: (_config, msg) => output.push(kolorist.stripColors(msg)),
     };
 
     const testCases = [{
@@ -49,18 +50,18 @@ async function run() {
 
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_ok')));
-    assert(! output.some(o => o.includes('FAILED test case section_fail')));
-    assert(output.some(o => o.includes('PASSED test case section_ok')));
-    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
+    assert(! output.some(o => o.includes(' FAILED  test case section_fail')));
+    assert(output.some(o => o.includes(' PASSED  test case section_ok')));
+    assert(output.some(o => o.includes(' FAILED  test case section_expectNothing_fail')));
     assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
 
     output = [];
     runnerConfig.expect_nothing = true;
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_ok')));
-    assert(output.some(o => o.includes('FAILED test case section_fail')));
+    assert(output.some(o => o.includes(' FAILED  test case section_fail')));
     assert(! output.some(o => o.includes('test case section_ok')));
-    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
+    assert(output.some(o => o.includes(' FAILED  test case section_expectNothing_fail')));
     assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
 }
 

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const kolorist = require('kolorist');
 
 const runner = require('../runner');
 const {expectedToFail} = require('../promise_utils');
@@ -11,7 +10,7 @@ async function run() {
         concurrency: 0,
         quiet: true,
         env: 'totallybroken',
-        logFunc: (_config, msg) => output.push(kolorist.stripColors(msg)),
+        logFunc: (_config, msg) => output.push(msg),
     };
 
     const testCases = [{

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -1,5 +1,4 @@
 const assert = require('assert');
-const kolorist = require('kolorist');
 const {generateDiff} = require('../output');
 
 async function run() {
@@ -7,7 +6,7 @@ async function run() {
         assert.deepEqual({foo: 123,bar:23}, {bar:23});
     } catch (err) {
         assert.equal(
-            kolorist.stripColors(generateDiff(err)).trim(),
+            generateDiff(err).trim(),
             [
                 '   {',
                 '  -  "foo": 123,',

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -9,11 +9,10 @@ async function run() {
         assert.equal(
             kolorist.stripColors(generateDiff(err)).trim(),
             [
-                '\n',
-                ' {',
-                '-  "foo": 123,',
-                '   "bar": 23',
-                ' }'
+                '   {',
+                '  -  "foo": 123,',
+                '     "bar": 23',
+                '   }'
             ].join('\n').trim()
         );
     }

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -1,4 +1,5 @@
 const assert = require('assert');
+const kolorist = require('kolorist');
 const {generateDiff} = require('../output');
 
 async function run() {
@@ -6,7 +7,7 @@ async function run() {
         assert.deepEqual({foo: 123,bar:23}, {bar:23});
     } catch (err) {
         assert.equal(
-            generateDiff(err).trim(),
+            kolorist.stripColors(generateDiff(err)).trim(),
             [
                 '\n',
                 ' {',


### PR DESCRIPTION
This PR adds colors to the logged output to make it a bit easier to scan for the eyes. The diff and the error stack trace have been slightly indented to better show a hierarchy.

```txt
STATUS MESSAGE
  DIFF
  STACK
```

Screenshots with color:
<img width="1249" alt="Screenshot 2020-04-29 at 16 26 07" src="https://user-images.githubusercontent.com/1062408/80608049-8dcb4f00-8a36-11ea-8e69-60efe6eb3e68.png">
<img width="919" alt="Screenshot 2020-04-29 at 16 25 45" src="https://user-images.githubusercontent.com/1062408/80608089-9754b700-8a36-11ea-8b92-0ef88b754b65.png">

Screenshot without color via: `NODE_DISABLE_COLORS=true`:

<img width="898" alt="Screenshot 2020-04-29 at 16 26 01" src="https://user-images.githubusercontent.com/1062408/80608140-a76c9680-8a36-11ea-8d23-83042648b0ba.png">


