### PR TITLE
Fix wrong diff output by sorting object properties

### DIFF
--- a/output.js
+++ b/output.js
@@ -115,14 +115,55 @@ function logVerbose(config, message) {
 }
 
 /**
- * Convert a value into a formatted string
+ * Indent string
+ * @param {number} n Levels of indentation
+ */
+function indent(n) {
+    return '  '.repeat(n);
+}
+
+/**
+ * Convert a value into a formatted string that can be used for
+ * comparisons. Contrary to `JSON.stringify(value, null, 2)` this
+ * will sort object properties which is necessary to get a meaningful
+ * diff.
  * @param {*} value Value to stringify
  * @returns {string}
  */
-function stringify(value) {
-    if (typeof value === 'string') return value;
-    if (value === undefined) return 'undefined';
-    return JSON.stringify(value, null, 2);
+function stringify(value, level = 0) {
+    if (typeof value === 'string') return `"${value}"`;
+    if (
+        typeof value === 'number'
+        || typeof value === 'boolean'
+        || value === undefined
+        || value === null
+    ) {
+        return '' + value;
+    }
+
+    const start = indent(level + 1);
+    const end = indent(level);
+    
+    if (Array.isArray(value)) {
+        if (value.length === 0) return '[]';
+        const items = value
+            .map(item => `${start}${stringify(item, level + 1)}`)
+            .join(',\n');
+        
+        return `[\n${items},\n${end}]`;
+    }
+
+    const keys = Object.keys(value);
+    if (!keys.length) return '{}';
+
+    const items = keys
+        .sort()
+        .map(key => {
+            return `${start}"${key}": ${stringify(value[key], level + 1)}`;
+        })
+        .join(',\n');
+    
+    return `{\n${items},\n${end}}`;
 }
 
 /**
@@ -186,4 +227,5 @@ module.exports = {
     logVerbose,
     generateDiff,
     status,
+    stringify,
 };

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -1,20 +1,112 @@
 const assert = require('assert');
 const {generateDiff} = require('../output');
 
-async function run() {
+function assertDiff(a, b, expected) {
     try {
-        assert.deepEqual({foo: 123,bar:23}, {bar:23});
+        assert.deepEqual(a, b);
     } catch (err) {
         assert.equal(
             generateDiff(err).trim(),
-            [
-                '   {',
-                '  -  "foo": 123,',
-                '     "bar": 23',
-                '   }'
-            ].join('\n').trim()
+            expected.join('\n').trim()
         );
     }
+}
+
+async function run() {
+    assertDiff(
+        {foo: 123, bar: 23},
+        {bar: 23},
+        [
+            '   {',
+            '     "bar": 23,',
+            '  -  "foo": 123,',
+            '   }'
+        ]
+    );
+
+    assertDiff(
+        {foo: 123, bar: 23},
+        {bar: 23, foo: 1},
+        [
+            '   {',
+            '     "bar": 23,',
+            '  -  "foo": 123,',
+            '  +  "foo": 1,',
+            '   }'
+        ]
+    );
+
+    assertDiff(
+        {foo: 123, bar: [1, 2]},
+        {bar: [2, 1], foo: 1},
+        [
+            '   {',
+            '     "bar": [',
+            '  +    2,',
+            '       1,',
+            '  -    2,',
+            '     ],',
+            '  -  "foo": 123,',
+            '  +  "foo": 1,',
+            '   }'
+        ]
+    );
+
+    assertDiff(
+        [1, {foo: 123}],
+        [{bar: 1}],
+        [
+            '   [',
+            '  -  1,',
+            '     {',
+            '  -    "foo": 123,',
+            '  +    "bar": 1,',
+            '     },',
+            '   ]'
+        ]
+    );
+
+    assertDiff(
+        { 
+            foo: [
+                1,
+                2,
+                undefined,
+                3,
+                {
+                    c: 123,
+                    b: [1, 2, 'asd', 'asdasd']
+                }
+            ]
+        }, 
+        {
+            foo: [
+                1,
+                2,
+                undefined,
+                {
+                    b: [1, 2, 'asdasd'],
+                    c: 123
+                }
+            ]
+        },
+        [
+            '    "foo": [',
+            '       1,',
+            '       2,',
+            '       undefined,',
+            '  -    3,',
+            '       {',
+            '         "b": [',
+            '           1,',
+            '           2,',
+            '  -        "asd",',
+            '           "asdasd",',
+            '         ],',
+            '         "c": 123,',
+            '       },',
+        ]
+    );
 }
 
 module.exports = {

--- a/tests/selftest_stringify.js
+++ b/tests/selftest_stringify.js
@@ -1,0 +1,108 @@
+const assert = require('assert');
+const {stringify} = require('../output');
+
+async function run() {
+    assert.equal(stringify(1), '1');
+    assert.equal(stringify(0), '0');
+    assert.equal(stringify(-10), '-10');
+    assert.equal(stringify('a'), '"a"');
+    assert.equal(stringify('abcde'), '"abcde"');
+    assert.equal(stringify(true), 'true');
+    assert.equal(stringify(false), 'false');
+    assert.equal(stringify(null), 'null');
+    assert.equal(stringify(undefined), 'undefined');
+
+    // Object
+    assert.equal(stringify({}), '{}');
+    assert.equal(stringify({ a: 123, b: null }), [
+        '{',
+        '  "a": 123,',
+        '  "b": null,',
+        '}'
+    ].join('\n'));
+    assert.equal(stringify({ b: null, a: 123 }), [
+        '{',
+        '  "a": 123,',
+        '  "b": null,',
+        '}'
+    ].join('\n'));
+    assert.equal(stringify({ b: { b1: 123 }, a: 123 }), [
+        '{',
+        '  "a": 123,',
+        '  "b": {',
+        '    "b1": 123,',
+        '  },',
+        '}'
+    ].join('\n'));
+    assert.equal(stringify({ b: {}, a: 123 }), [
+        '{',
+        '  "a": 123,',
+        '  "b": {},',
+        '}'
+    ].join('\n'));
+
+    // Array
+    assert.equal(stringify([1, 'a', null]), [
+        '[',
+        '  1,',
+        '  "a",',
+        '  null,',
+        ']'
+    ].join('\n'));
+    assert.equal(stringify([1, [1, 2]]), [
+        '[',
+        '  1,',
+        '  [',
+        '    1,',
+        '    2,',
+        '  ],',
+        ']'
+    ].join('\n'));
+    assert.equal(stringify([1, []]), [
+        '[',
+        '  1,',
+        '  [],',
+        ']'
+    ].join('\n'));
+
+    // Mixed
+    assert.equal(
+        stringify({ 
+            foo: [
+                1,
+                2,
+                undefined,
+                3,
+                {
+                    c: 123,
+                    b: [1, 2, 'asd', 'asdasd']
+                }
+            ]
+        }),
+        [
+            '{',
+            '  "foo": [',
+            '    1,',
+            '    2,',
+            '    undefined,',
+            '    3,',
+            '    {',
+            '      "b": [',
+            '        1,',
+            '        2,',
+            '        "asd",',
+            '        "asdasd",',
+            '      ],',
+            '      "c": 123,',
+            '    },',
+            '  ],',
+            '}'
+        ].join('\n'),
+    );
+}
+
+module.exports = {
+    description: 'Verify stringification',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
This is a follow-up to #71 .

Turns out that `JSON.stringify` doesn't sort object properties at all. This would lead the following comparison to fail:

```js
// actual
{ a: 1, b: 2 }
// vs expected
{ b: 2, a: 1 }
```

These are structurally the same objects and should not show any differences. Unfortunately for us `JSON.stringify` has no options to order object properties. I've looked at several npm packages as alternatives, but most are pretty heavy handed and come with ~20 or more dependencies. So I wrote a custom `stringify` function.