### PR TITLE
Remove debug code

### DIFF
--- a/tests/selftest_resultCountString.js
+++ b/tests/selftest_resultCountString.js
@@ -35,5 +35,4 @@ async function run() {
 module.exports = {
     description: 'Testing pentf itself: counting and classifying test results',
     run,
-    expectedToFail: 'yeah',
 };


### PR DESCRIPTION
This expectedToFail declaration was used for educational purposes and should never have been committed let alone made it into master.
