### PR TITLE
Fix colors

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,7 +1,6 @@
 /*eslint no-console: "off"*/
 
 const fs = require('fs');
-const kolorist = require('kolorist');
 const path = require('path');
 
 const {readConfig, parseArgs} = require('./config');
@@ -17,7 +16,6 @@ const {loadTests} = require('./loader');
 // - rootDir: Root directory (assume tests/ contains tests, config/ if exists contains config)
 // - testsDir: Test directory
 // - configDir: Configuration directory. false disables configuration.
-// - colors: Enable/Disable colors in stdout (default: true).
 async function real_main(options={}) {
     if (options.rootDir) {
         if (! options.testsDir) {
@@ -36,10 +34,6 @@ async function real_main(options={}) {
     const config = readConfig(options, args);
     if (options.defaultConfig) {
         options.defaultConfig(config);
-    }
-
-    if (options.colors === false || !config.colors) {
-        kolorist.options.enabled = false;
     }
 
     const test_cases = await loadTests(args, options.testsDir, options.testsGlob);

--- a/run
+++ b/run
@@ -16,5 +16,4 @@ pentf.main({
         config.report_header_md = 'This is the end-to-end test report in *markdown* form.';
         config.report_header_html = 'This is the end-to-end test report in <strong>HTML/PDF</strong> form.';
     },
-    colors: false
 });

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -5,6 +5,7 @@ const runner = require('../runner');
 async function run() {
     let output = [];
     const runnerConfig = {
+        colors: false,
         no_locking: true,
         concurrency: 0,
         quiet: true,

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -6,7 +6,7 @@ function assertDiff(a, b, expected) {
         assert.deepEqual(a, b);
     } catch (err) {
         assert.equal(
-            generateDiff(err).trim(),
+            generateDiff({}, err).trim(),
             expected.join('\n').trim()
         );
     }


### PR DESCRIPTION
`options` are meta-options defined by the tested application, that determine how to arrive at the config.
    
But `config` is what we want, as it is an amalgamation of CLI arguments and environment config (the latter of which would be somewhat unusual for colors here).
`config` can be nested though; in particular for the pentf self-tests. It would be a very sad state of affairs if the self-tests would not run with colors.
    
Therefore, move color enabling to our own helper function.