### PR TITLE
output: Reduce stack trace indent

### DIFF
--- a/output.js
+++ b/output.js
@@ -216,7 +216,7 @@ function formatError(err) {
     return err.stack
         .split('\n')
         // Indent stack trace
-        .map(line => '   ' + line)
+        .map(line => '  ' + line)
         .join('\n');
 }
 


### PR DESCRIPTION
Simplify the layout: Everything related to a failure is now indented by 2 instead of some stuff by 2 and other stuff by 3 levels deep.
Maybe in the future I'll add an option for no indent of stack traces, because that really looks best to me.
