### PR TITLE
Add Cookie support to net_utils.fetch

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const http = require('http');
 const https = require('https');
 const node_fetch = require('node-fetch');
+const tough = require('tough-cookie');
 
 const {makeCurlCommand} = require('./curl_command');
 const output = require('./output');
@@ -29,6 +30,13 @@ const {readFile} = require('./utils');
  * @param {*} config The pentf configuration object.
  * @param {string} url URL to fetch.
  * @param {Object?} init fetch options, see [`RequestInit` in the Fetch Spec](https://fetch.spec.whatwg.org/#requestinit).
+ * On top of the standard Fetch parameters, we support the following nonstandard parameters:
+ * - `agent`: node [HTTP/HTTPS agent](https://nodejs.org/api/https.html#https_class_https_agent)
+ * - `curl_include_headers`: boolean (default false) of whether to include `-k` in the curl output.
+ * - `curl_extra_options`: List of extra options for the curl output.
+ * - `cookieJar`: A [CookieJar object](https://github.com/salesforce/tough-cookie/blob/master/README.md#cookiejar) to use.
+ *               Pass in the string `'create'` to create a new one (returned as `response.cookieJar`).
+ *               The response will have a utility function `async getCookieValue(name)` to quickly retrieve a cookie value from the jar.
  */
 async function fetch(config, url, init) {
     if (!init) init = {};
@@ -50,6 +58,9 @@ async function fetch(config, url, init) {
     if (! init.headers) {
         init.headers = {};
     }
+    if (init.cookieJar && init.cookieJar !== 'create') {
+        init.headers.Cookie = await init.cookieJar.getCookieString(url);
+    }
     if (! Object.keys(init.headers).find(h => h.toLowerCase() === 'user-agent')) {
         init.headers['User-Agent'] = 'pentf integration test (https://github.com/boxine/pentf)';
     }
@@ -58,7 +69,31 @@ async function fetch(config, url, init) {
         output.log(config, await makeCurlCommand(init, url));
     }
 
-    return await node_fetch(url, init);
+    const response = await node_fetch(url, init);
+
+    let {cookieJar} = init;
+    if (cookieJar) {
+        if (cookieJar === 'create') {
+            cookieJar = new tough.CookieJar();
+        }
+
+        const setCookie = response.headers.raw()['set-cookie'];
+        if (Array.isArray(setCookie)) {
+            await Promise.all(
+                setCookie.map(c => cookieJar.setCookie(c, url))
+            );
+        } else {
+            assert(!setCookie); // No Set-Cookie header
+        }
+        response.cookieJar = cookieJar;
+        response.getCookieValue = async function getCookieValue(name) {
+            const cookies = await response.cookieJar.getCookies(url);
+            const cookie = cookies.find(c => c.key === name);
+            return cookie ? cookie.value : undefined;
+        };
+    }
+
+    return response;
 }
 
 async function setupTLSClientAuth(fetchOptions, keyFilename, certFilename, rejectUnauthorized=false) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2964,6 +2964,11 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
+      "integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+    },
     "pstree.remy": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.6.tgz",
@@ -2973,8 +2978,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "puppeteer": {
       "version": "2.1.1",
@@ -3694,6 +3698,16 @@
         "nopt": "~1.0.10"
       }
     },
+    "tough-cookie": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.0.0.tgz",
+      "integrity": "sha512-tHdtEpQCMrc1YLrMaqXXcj6AxhYi/xgit6mZu1+EDWUn+qhUf8wMQoFIy9NXuq23zAwtcB0t/MjACGR18pcRbg==",
+      "requires": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.1.2"
+      }
+    },
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
@@ -3808,8 +3822,7 @@
     "universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-      "dev": true
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
     },
     "unset-value": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.3.0",
     "stream-buffers": "^3.0.2",
-    "tmp-promise": "^2.0.2"
+    "tmp-promise": "^2.0.2",
+    "tough-cookie": "^4.0.0"
   },
   "devDependencies": {
     "@types/diff": "^4.0.2",

--- a/tests/selftest_fetch.js
+++ b/tests/selftest_fetch.js
@@ -1,0 +1,139 @@
+const assert = require('assert').strict;
+const http = require('http');
+const querystring = require('querystring');
+
+const {fetch} = require('../net_utils');
+
+function escapeHTML(s) {
+    // from https://stackoverflow.com/a/20403618/35070
+    return (s
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;'));
+}
+
+// NOT part of the official API, this is parsing cookies on the server side.
+// This is somewhat simplified and not a fully-fledged cookie parser
+function parseRequestCookies(request) {
+    request.cookies = {};
+
+    (request.headers.cookie || '').split(';').forEach(cookieStr => {
+        const [key, value] = cookieStr.trim().split('=', 2);
+        request.cookies[key] = value;
+    });
+}
+
+function handleRequest(request, response) {
+    parseRequestCookies(request);
+    if (request.url !== '/') {
+        response.writeHead(404, {});
+        response.end('404 Not Found');
+        return;
+    }
+
+    if (request.method === 'POST') {
+        // Parsing from https://stackoverflow.com/a/4310087/35070
+        let body = '';
+        request.on('data', data => {
+            body += data;
+            if (body.length > 1e6) request.connection.destroy();
+        });
+        request.on('end', function () {
+            const {name} = querystring.parse(body);
+
+            if (!name || !/^[-_a-zA-Z0-9_\s,;.]+$/.test(name)) {
+                response.writeHead(400);
+                response.end('Cannot parse POST');
+                return;
+            }
+
+            response.writeHead(302, {
+                'Location': '/',
+                'Set-Cookie': `name=${name}`,
+            });
+            response.end('302');
+        });
+        return;
+    }
+
+    const visitCount = request.cookies.visitCount ? parseInt(request.cookies.visitCount) : 0;
+    const setCookies = [
+        `previousVisit=${new Date().toString()}; SameSite=Lax`,
+        `visitCount=${visitCount + 1}`,
+    ];
+
+    response.writeHead(200, {
+        'Content-Type': 'text/html',
+        'Set-Cookie': setCookies,
+    });
+    response.end(`<!DOCTYPE html><html><body>
+        <h1>Hello ${escapeHTML(request.cookies.name || 'anonymous')}!</h1>
+        Previous visit: ${escapeHTML(request.cookies.previousVisit || 'never')}
+        Visit count: ${escapeHTML('' + request.cookies.visitCount)}
+        <form method="post">
+        <input name="name" />
+        <button type="submit">Set my name</button>
+        </form>
+        </body></html>`);
+}
+
+async function run(config) {
+    const clientSockets = new Map();
+    let socketCounter = 0;
+    const server = http.createServer(handleRequest);
+    server.on('connection', socket => {
+        const socketId = socketCounter++;
+        clientSockets.set(socketId, socket);
+        socket.on('close', function () {
+            clientSockets.delete(socketId);
+        });
+    });
+    const port = await new Promise((resolve, reject) => {
+        server.listen(0, (err) => {
+            if (err) return reject(err);
+
+            const {port} = server.address();
+            return resolve(port);
+        });
+    });
+    const url = `http://localhost:${port}/`;
+
+    let response = await fetch(config, url, {cookieJar: 'create'});
+    assert.equal(response.status, 200);
+    assert.equal(await response.getCookieValue('visitCount'), '1');
+    const cookieJar = response.cookieJar;
+
+    response = await fetch(config, url, {cookieJar});
+    assert.equal(response.status, 200);
+    assert.equal(await response.getCookieValue('visitCount'), '2');
+
+    response = await fetch(config, url, {
+        cookieJar,
+        method: 'POST',
+        body: `name=${encodeURIComponent('John Smith')}`,
+        redirect: 'manual',
+    });
+    assert.equal(response.status, 302);
+    assert.equal(await response.getCookieValue('visitCount'), '2');
+    assert.equal(await response.getCookieValue('name'), 'John Smith');
+
+    response = await fetch(config, url, {cookieJar});
+    assert.equal(response.status, 200);
+    const html = (await response.text());
+    assert(html.includes('Hello John Smith'));
+    assert(html.includes('Visit count: 2'));
+    assert.equal(await response.getCookieValue('name'), 'John Smith');
+    assert.equal(await response.getCookieValue('visitCount'), '3');
+
+    // Terminate server
+    server.close(); // No new connections
+    for (const socket of clientSockets.values()) {
+        socket.destroy();
+    }
+}
+
+module.exports = {
+    description: 'net_utils.fetch, namely cookie handling',
+    run,
+};


### PR DESCRIPTION
For backend tests against traditional HTML & Cookie (rather than API & Token) applications, we need cookie support. One way to get that and much more is to fire up a real browser (with `browser_utils.newPage` or otherwise), but that is very resource-intensive and may break because of other stuff (e.g. CDNs).

Start a new era of enabling browser-less tests by adding cookie jar support to `net_utils.fetch`.
Also add a self-test for that.
