### PR TITLE
Fix duplicate diff with assert.strict

### DIFF
--- a/output.js
+++ b/output.js
@@ -176,13 +176,19 @@ function generateDiff(config, err) {
     assert(err);
 
     const showDiff = err
-        // Chaijs adds this property if the diff should be shown
-        && err.showDiff !== false
+    && (
+        // Chaijs adds this property if the diff should be shown. Assert
+        // Will automatically append a diff to `err.stack` in strict mode.
+        err.showDiff
+            // If assert is not in strict mode or for some reason the diff
+            // is missing, we will append our own nonetheless
+            || !err.stack.slice(1).includes('+ expected')
+    )
         // Check if actual and expected are the same type
         && Object.prototype.toString.call(err.actual) === Object.prototype.toString.call(err.expected)
         // We can't generate a diff if the expected value is not present
         && err.expected !== undefined;
-        
+
     if (!showDiff) return '';
 
     // The "diff" package works on strings only

--- a/runner.js
+++ b/runner.js
@@ -77,7 +77,7 @@ async function run_task(config, task) {
                 output.log(
                     config,
                     `${label} test case ${name} at ${utils.localIso8601()}:\n` +
-                    `${output.generateDiff(config, e)}${output.formatError(e)}\n`);
+                    `${output.formatError(config, e)}\n`);
             }
         }
         if (config.fail_fast) {

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -2,14 +2,10 @@ const assert = require('assert');
 const {generateDiff} = require('../output');
 
 function assertDiff(a, b, expected) {
-    try {
-        assert.deepEqual(a, b);
-    } catch (err) {
-        assert.equal(
-            generateDiff({}, err).trim(),
-            expected.join('\n').trim()
-        );
-    }
+    assert.equal(
+        generateDiff({}, {actual: a, expected: b}).trim(),
+        expected.join('\n').trim()
+    );
 }
 
 async function run() {
@@ -107,17 +103,6 @@ async function run() {
             '       },',
         ]
     );
-
-    // Don't add diff if already present. Strict mode in assert
-    // will always add a diff
-    try {
-        assert.strict.deepEqual([1], [2]);
-    } catch (err) {
-        assert.equal(
-            generateDiff({}, err).trim(),
-            ''
-        );
-    }
 }
 
 module.exports = {

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -107,6 +107,17 @@ async function run() {
             '       },',
         ]
     );
+
+    // Don't add diff if already present. Strict mode in assert
+    // will always add a diff
+    try {
+        assert.strict.deepEqual([1], [2]);
+    } catch (err) {
+        assert.equal(
+            generateDiff({}, err).trim(),
+            ''
+        );
+    }
 }
 
 module.exports = {


### PR DESCRIPTION
TIL, that `assert` will automatically add a diff output to `error.stack` if it's used in strict mode. Didn't even know that it existed in the first place! This unfortunately lead to duplicate diffs being displayed.

With this PR we'll check if there is a diff already present in the output and we'll only add our diff if it is not there.