### PR TITLE
Advertise and use strict assert mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ to execute all tests. You may also want to have a look at the [options](#options
 Plop a new `.js` file into `tests/`. Its name will be the test''s name, and it should have an async `run` function, like this:
 
 ```javascript
-const assert = require('assert');
+const assert = require('assert').strict;
 const {getMail} = require('pentf/email');
 const {newPage, closePage} = require('pentf/browser_utils');
 const {fetch} = require('pentf/net_utils');
@@ -196,6 +196,14 @@ const response = await fetch(`https://example.org/widget/${id}`);
 assert.equal(response.status, 200);
 const text = await response.text();
 ```
+
+### Use `assert` in strict mode
+
+In [strict assertion mode](https://nodejs.org/api/assert.html#assert_strict_assertion_mode), `assert` generates better errors and is generally easier to deal with.
+
+**Avoid**: `const assert = require('assert');`
+
+**Use**: `const assert = require('assert').strict;`
 
 ## Configuration
 

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -5,7 +5,7 @@
  * @packageDocumentation
  */
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const fs = require('fs');
 const path = require('path');
 const {promisify} = require('util');

--- a/config.js
+++ b/config.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const argparse = require('argparse');
-const assert = require('assert');
+const assert = require('assert').strict;
 const fs = require('fs');
 const path = require('path');
 

--- a/curl_command.js
+++ b/curl_command.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const streamBuffers = require('stream-buffers');
 
 async function stream2buf(stream) {

--- a/email.js
+++ b/email.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const {TextDecoder} = require('util');
 
 const imap_client_module = require('emailjs-imap-client');

--- a/external_locking.js
+++ b/external_locking.js
@@ -1,6 +1,6 @@
 // Locking functions for communication with the lockserver
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const os = require('os');
 
 const {fetch} = require('./net_utils');

--- a/locking.js
+++ b/locking.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const output = require('./output');
 const {wait} = require('./utils');

--- a/lockserver/lockserver.js
+++ b/lockserver/lockserver.js
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 const argparse = require('argparse');
-const assert = require('assert');
+const assert = require('assert').strict;
 const http = require('http');
 const he = require('he');
 

--- a/lockserver/server_utils.js
+++ b/lockserver/server_utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 function readBody(request) {
     return new Promise((resolve, reject) => {

--- a/net_utils.js
+++ b/net_utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const http = require('http');
 const https = require('https');
 const node_fetch = require('node-fetch');

--- a/output.js
+++ b/output.js
@@ -1,6 +1,6 @@
 // Functions to output the current state.
 // For functions to render the state _after_ the tests have finished, look in render.js .
-const assert = require('assert');
+const assert = require('assert').strict;
 const readline = require('readline');
 const diff = require('diff');
 const kolorist = require('kolorist');

--- a/pentf_example.js
+++ b/pentf_example.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const {getMail} = require('pentf/email');
 const {newPage, closePage} = require('pentf/browser_utils');
 const {fetch} = require('pentf/net_utils');

--- a/promise_utils.js
+++ b/promise_utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const output = require('./output');
 

--- a/results.js
+++ b/results.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const utils = require('./utils');
 

--- a/runner.js
+++ b/runner.js
@@ -1,6 +1,6 @@
 /* eslint no-console: 0 */
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const path = require('path');
 const {performance} = require('perf_hooks');
 const {promisify} = require('util');

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const runner = require('../runner');
 

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const runner = require('../runner');
 const {expectedToFail} = require('../promise_utils');

--- a/tests/selftest_assertEventually.js
+++ b/tests/selftest_assertEventually.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {assertEventually} = require('../utils');
 

--- a/tests/selftest_attributes.js
+++ b/tests/selftest_attributes.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {closePage, newPage, getAttribute, getText} = require('../browser_utils');
 

--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {assertNotXPath, clickXPath, clickText, waitForText, closePage, newPage} = require('../browser_utils');
 const {assertEventually} = require('../utils');

--- a/tests/selftest_clickNestedText.js
+++ b/tests/selftest_clickNestedText.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {closePage, newPage, clickNestedText} = require('../browser_utils');
 

--- a/tests/selftest_clickTestId.js
+++ b/tests/selftest_clickTestId.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {closePage, newPage, clickTestId} = require('../browser_utils');
 const {assertEventually} = require('../utils');

--- a/tests/selftest_diff.js
+++ b/tests/selftest_diff.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const {generateDiff} = require('../output');
 
 function assertDiff(a, b, expected) {

--- a/tests/selftest_email.js
+++ b/tests/selftest_email.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {parseHeader} = require('../email');
 

--- a/tests/selftest_extension.js
+++ b/tests/selftest_extension.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const path = require('path');
 const {closePage, newPage} = require('../browser_utils');
 

--- a/tests/selftest_maxeventlisteners.js
+++ b/tests/selftest_maxeventlisteners.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const child_process = require('child_process');
 const path = require('path');
 

--- a/tests/selftest_render_linkify.js
+++ b/tests/selftest_render_linkify.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {_linkify: linkify} = require('../render');
 

--- a/tests/selftest_speedupTimeouts.js
+++ b/tests/selftest_speedupTimeouts.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {speedupTimeouts, restoreTimeouts, closePage, newPage} = require('../browser_utils');
 const {assertAlways, assertEventually} = require('../utils');

--- a/tests/selftest_stringify.js
+++ b/tests/selftest_stringify.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const {stringify} = require('../output');
 
 async function run() {

--- a/tests/selftest_timeoutPromise.js
+++ b/tests/selftest_timeoutPromise.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {timeoutPromise} = require('../promise_utils');
 const {wait} = require('../utils');

--- a/tests/selftest_utils.js
+++ b/tests/selftest_utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {timezoneOffsetString} = require('../utils');
 

--- a/tests/selftest_version.js
+++ b/tests/selftest_version.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const child_process = require('child_process');
 const path = require('path');
 const {promisify} = require('util');

--- a/tests/selftest_waitForTestId.js
+++ b/tests/selftest_waitForTestId.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {closePage, newPage, waitForTestId} = require('../browser_utils');
 

--- a/tests/selftest_waitForVisible.js
+++ b/tests/selftest_waitForVisible.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {closePage, newPage, waitForVisible} = require('../browser_utils');
 

--- a/tests/test_lockserver.js
+++ b/tests/test_lockserver.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 
 const {fetch} = require('../net_utils');
 const {externalList, externalAcquire, externalRelease} = require('../external_locking');

--- a/update-readme.js
+++ b/update-readme.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-const assert = require('assert');
+const assert = require('assert').strict;
 const child_process = require('child_process');
 const fs = require('fs');
 const path = require('path');

--- a/utils.js
+++ b/utils.js
@@ -1,4 +1,4 @@
-const assert = require('assert');
+const assert = require('assert').strict;
 const fs = require('fs');
 
 function makeEmailAddress(config, suffix) {


### PR DESCRIPTION
Out of the box, the [strict assertion mode](https://nodejs.org/api/assert.html#assert_strict_assertion_mode) is much nicer to use.
Use it in all our code and add a tip to use it.
