### PR TITLE
Apply --no-colors to assert.strict

### DIFF
--- a/main.js
+++ b/main.js
@@ -36,6 +36,11 @@ async function real_main(options={}) {
         options.defaultConfig(config);
     }
 
+    if (!config.colors) {
+        // Trick other libraries (e.g. node's assert.strict) into not using colors
+        process.env.NODE_DISABLE_COLORS = 'true';
+    }
+
     const test_cases = await loadTests(args, options.testsDir, options.testsGlob);
     config._testsDir = options.testsDir;
     if (options.rootDir) config._rootDir = options.rootDir;


### PR DESCRIPTION
When using `--no-colors`, for example to debug a problem with coloring assertions, then builtin functions like `assert.strict` should follow suit.
This does not work for nested configurations, but perfect is the enemy of good, and this seems like a sensible workaround to get the correct behavior.
