### PR TITLE
Allow JavaScript (.js) configuration files

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,10 +207,19 @@ In [strict assertion mode](https://nodejs.org/api/assert.html#assert_strict_asse
 
 ## Configuration
 
-pentf is designed to be run against different configurations, e.g. local/dev/stage/prod. Create JSON files in the `config` subdirectory for each environment. You can also add a programatic configuration by passing a function `defaultConfig` to `pentf.main`; see [pentf's own run](run) for an example. 
+pentf is designed to be run against different configurations, e.g. local/dev/stage/prod. Create files in the `config` subdirectory for each environment, in one of the following formats:
 
-The keys are up to you; for example you probably want to have a main entry point. Predefined keys are:
+- JSON: A `.json` file with the keys and associated values. ([example](tests/config_examples/json.json))
+- Simple JavaScript: A `.js` file which exports the configuration. ([example](tests/config_examples/simple_javascript.js))
+- Async JavaScript: A `.js` file which exports an async function being called with the environment name and returning the configuration. ([example](tests/config_examples/async_javascript.js))
 
+You can also add a programatic configuration for multiple environments by passing a function `defaultConfig` to `pentf.main`; see [pentf's own run](run) for an example.
+
+The keys are up to you; for example you probably want to have a main entry point. pentf claims the following keys:
+
+- **`extends`** Inherit from the specified environment. It is common to have a `_common` environment (i.e. a file `_common.json` or `common.`) which all environments inherit from. You can also construct combined environments, e.g. prod backend with a development frontend.
+- **`external_locking_url`** Base URL of the external lockserver to use to avoid test runs on different machines using shared resources (such as test accounts, limited widgets etc.) at the same time (see _locking_ below).
+- **`email`** The base email address used in [`makeRandomEmail`](https://boxine.github.io/pentf/modules/_utils_.html#makerandomemail).
 - **`imap`** If you are using the `pentf/email` module to fetch and test emails, configure your imap connection here, like
 ```
   "imap": {

--- a/config/localhost.js
+++ b/config/localhost.js
@@ -1,0 +1,10 @@
+// .js files can run arbitrary JavaScript code.
+
+// Just export the configuration:
+module.exports = {
+    extends: '_common',
+
+    pentf_boot_lockserver: false,
+    external_locking_url: 'http://localhost:1524/pentf-localhost',
+    pentf_lockserver_url: 'http://localhost:1524/pentf-internal',
+};

--- a/config/localhost.json
+++ b/config/localhost.json
@@ -1,7 +1,0 @@
-{
-	"extends": "_common",
-
-	"pentf_boot_lockserver": false,
-	"external_locking_url": "http://localhost:1524/pentf-localhost",
-	"pentf_lockserver_url": "http://localhost:1524/pentf-internal"
-}

--- a/main.js
+++ b/main.js
@@ -31,7 +31,7 @@ async function real_main(options={}) {
 
 
     const args = parseArgs(options);
-    const config = readConfig(options, args);
+    const config = await readConfig(options, args);
     if (options.defaultConfig) {
         options.defaultConfig(config);
     }

--- a/tests/config_examples/async_javascript.js
+++ b/tests/config_examples/async_javascript.js
@@ -1,0 +1,11 @@
+// A complex JavaScript configuration file can run arbitrary async code
+module.exports = async (env) => {
+    // We could download something here, or read a file, or ...
+    await new Promise(resolve => resolve());
+
+    return {
+        async_loaded: true,
+        overriden: 'async_javascript',
+        server: `https://${env}.example.org/`,
+    };
+};

--- a/tests/config_examples/json.json
+++ b/tests/config_examples/json.json
@@ -1,0 +1,13 @@
+{
+    "doc:file": "A JSON configuration is simply a JSON file.",
+
+    "extends": "simple_javascript",
+    "doc:extends": [
+        "In any configuration file, you can set an extends key to inherit from another configuration",
+        "If a key occurs here and in the parent configuration, the value here will be used."
+    ],
+
+    "json_loaded": true,
+    "external_locking_url": "https://lockserver.example/",
+    "overriden": "json"
+}

--- a/tests/config_examples/simple_javascript.js
+++ b/tests/config_examples/simple_javascript.js
@@ -1,0 +1,15 @@
+// A Simple JavaScript configuration file just exports its configuration
+
+function calc_main_url() {
+    return 'https://example.org/';
+}
+
+module.exports = {
+    extends: 'async_javascript',
+
+    shop_prefix: 'https://shop.example.org/buy/',
+    main_url: calc_main_url(),
+    simple_loaded: true,
+
+    overriden: 'simple_javascript',
+};

--- a/tests/selftest_config.js
+++ b/tests/selftest_config.js
@@ -1,0 +1,21 @@
+const assert = require('assert').strict;
+const path = require('path');
+const {_readConfigFile: readConfigFile} = require('../config');
+
+async function run() {
+    const exampleDir = path.join(__dirname, 'config_examples');
+    const exampleConfig = await readConfigFile(exampleDir, 'json');
+
+    assert(exampleConfig.json_loaded);
+    assert(exampleConfig.simple_loaded);
+    assert(exampleConfig.async_loaded);
+    assert.equal(exampleConfig.overriden, 'json');
+    assert.equal(exampleConfig.server, 'https://async_javascript.example.org/');
+    assert.equal(exampleConfig.external_locking_url, 'https://lockserver.example/');
+}
+
+module.exports = {
+    description: 'pentf configuration',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Previously, the configuration files had to be JSON, named `config/${ENV}.json`, with `${ENV}` standing for the environment.

This is fine for most applications, but in some cases it may be desirable to use `.js` – to add comments, or event to compute the configuration (e.g. download information somewhere).
Therefore, allow JavaScript files, both ones that directly export the configuration and ones that export an async function that computes it.

Add a test for reading the configuration that doubles as examples.

While we're at it, also extend the config documentation.

In the future, we may also add YAML and TypeScript support.
