### PR TITLE
Allow tests to provide a reason for skipping

### DIFF
--- a/render.js
+++ b/render.js
@@ -10,7 +10,7 @@ function craftResults(config, test_info) {
     const {test_start, test_end, state, ...moreInfo} = test_info;
     const {tasks} = state;
     const test_results = tasks.map(s => {
-        const res = utils.pluck(s, ['status', 'name', 'duration', 'error_screenshots', 'expectedToFail']);
+        const res = utils.pluck(s, ['status', 'name', 'duration', 'error_screenshots', 'expectedToFail', 'skipReason']);
 
         if (s.error) {
             res.error_stack = s.error.stack;
@@ -160,10 +160,13 @@ function html(results) {
     const table = results.tests.map((test_result, idx) => {
         const errored = test_result.status === 'error';
         const skipped = test_result.status === 'skipped';
-        const status_str = {
+        let status_str = {
             'success': '✔️',
             'error': '✘',
         }[test_result.status] || test_result.status;
+        if (skipped && test_result.skipReason) {
+            status_str = 'skipped: ' + test_result.skipReason;
+        }
 
         const rowspan = (
             1 +

--- a/runner.js
+++ b/runner.js
@@ -216,8 +216,12 @@ function testCases2tasks(config, testCases) {
             id: tc.name,
         };
 
-        if (tc.skip && tc.skip(config)) {
+        const skipReason = tc.skip && tc.skip(config);
+        if (skipReason) {
             task.status = 'skipped';
+            if (typeof skipReason === 'string') {
+                task.skipReason = skipReason;
+            }
         }
 
         if (Object.prototype.hasOwnProperty.call(tc, 'expectedToFail')) {

--- a/tests/browser_failure.js
+++ b/tests/browser_failure.js
@@ -18,5 +18,5 @@ module.exports = {
     description: 'Reproduces a browser failure. This is not a selftest; more of a demo.',
     resources: [],
     run,
-    skip: () => !process.env.PENTF_DEMO,
+    skip: () => !process.env.PENTF_DEMO && 'PENTF_DEMO environment variable not set',
 };


### PR DESCRIPTION
Just like `expectedToFail`, allow the `skip` function to return a string, and output that string in the results HTML/PDF.

This can be used like this:
```
    skip: config => (config.env === 'prod') && 'This DoS could impact customers and is therefore not run against prod';
```
