### PR TITLE
Only pad status label when colors are enabled

### DIFF
--- a/output.js
+++ b/output.js
@@ -229,6 +229,11 @@ function color(config, colorName, str) {
         return str;
     }
 
+    // Labels like "FAILED" or "PASSED" need a bit of visual padding.
+    if (['FAILED', 'PASSED'].includes(str)) {
+        str = ` ${str} `;
+    }
+
     const m = /^inverse-(.*)$/.exec(colorName);
     if (m) {
         colorName = m[1];

--- a/runner.js
+++ b/runner.js
@@ -24,7 +24,7 @@ async function run_task(config, task) {
         task.duration = performance.now() - task.start;
         if (task.expectedToFail && !config.expect_nothing) {
             const etf = (typeof task.expectedToFail === 'string') ? ` (${task.expectedToFail})` : '';
-            const label = output.color(config, 'inverse-red', ' PASSED ');
+            const label = output.color(config, 'inverse-red', 'PASSED');
             output.log(
                 config,
                 `${label} test case ${output.color(config, 'lightCyan', task.name)}` +
@@ -74,11 +74,11 @@ async function run_task(config, task) {
         if (show_error) {
             const name = output.color(config, 'lightCyan', task.name);
             if (e.pentf_expectedToSucceed) {
-                const label = output.color(config, 'inverse-green', ' PASSED ');
+                const label = output.color(config, 'inverse-green', 'PASSED');
                 output.log(
                     config, `${label} test case ${name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
             } else {
-                const label = output.color(config, 'inverse-red', ' FAILED ');
+                const label = output.color(config, 'inverse-red', 'FAILED');
                 output.log(
                     config,
                     `${label} test case ${name} at ${utils.localIso8601()}:\n` +

--- a/tests/expectedToFail.js
+++ b/tests/expectedToFail.js
@@ -1,3 +1,4 @@
+
 const assert = require('assert').strict;
 
 const runner = require('../runner');
@@ -43,18 +44,18 @@ async function run() {
 
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_success')));
-    assert(output.some(o => o.includes(' FAILED  test case normal_failure')));
-    assert(! output.some(o => o.includes(' FAILED  test case expected_failure_true')));
-    assert(! output.some(o => o.includes(' FAILED  test case works_except_on_totallybroken')));
-    assert(output.some(o => o.includes(' PASSED  test case unexpected_success')));
+    assert(output.some(o => o.includes('FAILED test case normal_failure')));
+    assert(! output.some(o => o.includes('FAILED test case expected_failure_true')));
+    assert(! output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
+    assert(output.some(o => o.includes('PASSED test case unexpected_success')));
     assert(! output.some(o => o.includes('test case expected_success')));
 
     output = [];
     runnerConfig.expect_nothing = true;
     await runner.run(runnerConfig, testCases);
-    assert(output.some(o => o.includes(' FAILED  test case normal_failure')));
-    assert(output.some(o => o.includes(' FAILED  test case expected_failure_true')));
-    assert(output.some(o => o.includes(' FAILED  test case works_except_on_totallybroken')));
+    assert(output.some(o => o.includes('FAILED test case normal_failure')));
+    assert(output.some(o => o.includes('FAILED test case expected_failure_true')));
+    assert(output.some(o => o.includes('FAILED test case works_except_on_totallybroken')));
 }
 
 module.exports = {

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -49,18 +49,18 @@ async function run() {
 
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_ok')));
-    assert(! output.some(o => o.includes(' FAILED  test case section_fail')));
-    assert(output.some(o => o.includes(' PASSED  test case section_ok')));
-    assert(output.some(o => o.includes(' FAILED  test case section_expectNothing_fail')));
+    assert(! output.some(o => o.includes('FAILED test case section_fail')));
+    assert(output.some(o => o.includes('PASSED test case section_ok')));
+    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
     assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
 
     output = [];
     runnerConfig.expect_nothing = true;
     await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_ok')));
-    assert(output.some(o => o.includes(' FAILED  test case section_fail')));
+    assert(output.some(o => o.includes('FAILED test case section_fail')));
     assert(! output.some(o => o.includes('test case section_ok')));
-    assert(output.some(o => o.includes(' FAILED  test case section_expectNothing_fail')));
+    assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
     assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
 }
 


### PR DESCRIPTION
Before (colors disabled):

```txt
 FAILED  test case expectedToFail at 2020-05-12T11:51:50.703+02:00:
  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
```

After (colors disabled:

```txt
FAILED test case expectedToFail at 2020-05-12T11:51:50.703+02:00:
  AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:
```