### PR TITLE
browser_utils: Modernize assertNotXPath

### DIFF
--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -7,9 +7,11 @@ async function run(config) {
     const page = await newPage(config);
     await page.setContent('<div id="d1"><div id="d2">test" text \\ " a</div></div>');
 
-    await assert.rejects(assertNotXPath(page, '//div[@id="d2"]', 'extra', 10, 1), {
-        message: 'Element matching //div[@id="d2"] is present, but should not be there. extra',
-    });
+    await assert.rejects(
+        assertNotXPath(
+            page, '//div[@id="d2"]', {message: 'extra', timeout: 10, checkEvery: 1}),
+        {message: 'Element matching //div[@id="d2"] is present, but should not be there. extra'}
+    );
     await assertNotXPath(page, '//div[@id="d3"]');
 
     await waitForText(page, 'test');


### PR DESCRIPTION
All our other functions take the error message as an optional named parameter `message`, but this was one of the few holdouts from the early times.
Allow both the legacy way of calling and the new one.

After a couple of releases, we will add a deprecation warning to the legacy code path, and then finally remove it.

Also add an assertion that `XPath` is a string – if the user passes in a function or `undefined`, that may end up being a valid XPath when converted to a string by accident.
