### PR TITLE
Add --repeat option

### DIFF
--- a/config.js
+++ b/config.js
@@ -241,6 +241,11 @@ function parseArgs(options) {
         help: 'Terminate with exit code 0 (success) even if tests fail. (Exit codes != 0 are still emitted in cases of internal crashes)',
         action: 'storeTrue',
     });
+    runner_group.addArgument(['--repeat'], {
+        type: 'int',
+        defaultValue: 1,
+        help: 'Run the tests the specified number of times (experimental)',
+    });
 
     const locking_group = parser.addArgumentGroup({title: 'Locking'});
     locking_group.addArgument(['-L', '--no-locking'], {

--- a/output.js
+++ b/output.js
@@ -40,7 +40,7 @@ function status(config, state) {
     let status_str;
     for (let running_show = running.length;running_show >= 0;running_show--) {
         const running_str = (
-            running.slice(0, running_show).map(({tc}) => tc.name).join(' ')
+            running.slice(0, running_show).map(task => task.name).join(' ')
             + (running_show < running.length ? '  +' + (running.length - running_show) : '')
         );
         status_str = (


### PR DESCRIPTION
To identify flaky tests, it is very helpful to be able to re-run them multiple times.
Add a `--repeat` option that does exactly that.
