### PR TITLE
Improve docs for --repeat

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ The keys are up to you; for example you probably want to have a main entry point
                       Do not output error messages matching the regular expression. Example: -I 
                       "\(TOC-[0-9]+\)"
 -E, --expect-nothing  Ignore expectedToFail attributes on tests
+--no-colors           Disable colors in stdout
 ```
 
 ###### Writing results to disk
@@ -348,6 +349,7 @@ The keys are up to you; for example you probably want to have a main entry point
 --print-tasks         Output all tasks that the runner would perform, and exit
 --exit-zero           Terminate with exit code 0 (success) even if tests fail. (Exit codes != 0 are still 
                       emitted in cases of internal crashes)
+--repeat COUNT        Run the tests the specified number of times
 ```
 
 ###### Locking

--- a/config.js
+++ b/config.js
@@ -243,8 +243,9 @@ function parseArgs(options) {
     });
     runner_group.addArgument(['--repeat'], {
         type: 'int',
+        metavar: 'COUNT',
         defaultValue: 1,
-        help: 'Run the tests the specified number of times (experimental)',
+        help: 'Run the tests the specified number of times',
     });
 
     const locking_group = parser.addArgumentGroup({title: 'Locking'});


### PR DESCRIPTION
The feature is not really experimental anymore. Also add a more helpful metavar for the `--help` output.
Regenerate the README as well.
