### PR TITLE
Improve browser_failure test

### DIFF
--- a/tests/browser_failure.js
+++ b/tests/browser_failure.js
@@ -6,10 +6,11 @@ async function run(config) {
     await closePage(closed);
 
     const page0 = await newPage(config);
-    await page0.setContent('This is the first page');
+    await page0.setContent('<style>*{font-size:50px;}</style>This is the first page.');
 
     const foreground = await newPage(config);
-    await foreground.setContent('<style>*{background:#f88;}</style>This is the second page');
+    await foreground.setContent(
+        '<style>*{font-size:50px;background:#f88;}</style>This is the second page.');
 
     throw new Error('Test failed (this will cause screenshots)');
 }
@@ -19,4 +20,7 @@ module.exports = {
     resources: [],
     run,
     skip: () => !process.env.PENTF_DEMO && 'PENTF_DEMO environment variable not set',
+    expectedToFail: () => process.env.PENTF_DEMO && (
+        'This test will fail in order to demonstrate how pentf handles errors.' +
+        ' In a real test, we would likely mention a ticket number or URL here.'),
 };


### PR DESCRIPTION
This test serves as a demonstration vehicle to show off pentf's result rendering.
Add `expectedToFail` and make the text easy to read.
