### PR TITLE
render: Make expectedToFailText cover 3 columns

### DIFF
--- a/render.js
+++ b/render.js
@@ -258,7 +258,7 @@ function html(results) {
         if (testResult.expectedToFail) {
             res += (
                 `<tr class="${idx % 2 != 0 ? 'odd' : ''}">` +
-                '<td class="expectedToFail" colspan="2">' +
+                '<td class="expectedToFail" colspan="3">' +
                 ((typeof testResult.expectedToFail === 'string')
                     ? 'Expected to fail: ' + linkify(testResult.expectedToFail)
                     : 'Expected to fail.'


### PR DESCRIPTION
Just like the screenshots below, this text can cover all 3 columns.
(Before, a table cell was missing, so it looked funny with gray background.)
