### PR TITLE
Add Sentry support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,92 @@
         "js-tokens": "^4.0.0"
       }
     },
+    "@sentry/apm": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/apm/-/apm-5.15.5.tgz",
+      "integrity": "sha512-2PyifsiQdvFEQhbL7tQnCKGLOO1JtZeqso3bc6ARJBvKxM77mtyMo/D0C2Uzt9sXCYiALhQ1rbB1aY8iYyglpg==",
+      "requires": {
+        "@sentry/browser": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/browser": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/browser/-/browser-5.15.5.tgz",
+      "integrity": "sha512-rqDvjk/EvogfdbZ4TiEpxM/lwpPKmq23z9YKEO4q81+1SwJNua53H60dOk9HpRU8nOJ1g84TMKT2Ov8H7sqDWA==",
+      "requires": {
+        "@sentry/core": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/core": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-5.15.5.tgz",
+      "integrity": "sha512-enxBLv5eibBMqcWyr+vApqeix8uqkfn0iGsD3piKvoMXCgKsrfMwlb/qo9Ox0lKr71qIlZVt+9/A2vZohdgnlg==",
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/minimal": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/hub": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/hub/-/hub-5.15.5.tgz",
+      "integrity": "sha512-zX9o49PcNIVMA4BZHe//GkbQ4Jx+nVofqU/Il32/IbwKhcpPlhGX3c1sOVQo4uag3cqd/JuQsk+DML9TKkN0Lw==",
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/minimal": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/minimal/-/minimal-5.15.5.tgz",
+      "integrity": "sha512-zQkkJ1l9AjmU/Us5IrOTzu7bic4sTPKCatptXvLSTfyKW7N6K9MPIIFeSpZf9o1yM2sRYdK7GV08wS2eCT3JYw==",
+      "requires": {
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/node": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-5.15.5.tgz",
+      "integrity": "sha512-BK0iTOiiIM0UnydLeT/uUBY1o1Sp85aqwaQRMfZbjMCsgXERLNGvzzV68FDH1cyC1nR6dREK3Gs8bxS4S54aLQ==",
+      "requires": {
+        "@sentry/apm": "5.15.5",
+        "@sentry/core": "5.15.5",
+        "@sentry/hub": "5.15.5",
+        "@sentry/types": "5.15.5",
+        "@sentry/utils": "5.15.5",
+        "cookie": "^0.3.1",
+        "https-proxy-agent": "^4.0.0",
+        "lru_map": "^0.3.3",
+        "tslib": "^1.9.3"
+      }
+    },
+    "@sentry/types": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-5.15.5.tgz",
+      "integrity": "sha512-F9A5W7ucgQLJUG4LXw1ZIy4iLevrYZzbeZ7GJ09aMlmXH9PqGThm1t5LSZlVpZvUfQ2rYA8NU6BdKJSt7B5LPw=="
+    },
+    "@sentry/utils": {
+      "version": "5.15.5",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-5.15.5.tgz",
+      "integrity": "sha512-Nl9gl/MGnzSkuKeo3QaefoD/OJrFLB8HmwQ7HUbTXb6E7yyEzNKAQMHXGkwNAjbdYyYbd42iABP6Y5F/h39NtA==",
+      "requires": {
+        "@sentry/types": "5.15.5",
+        "tslib": "^1.9.3"
+      }
+    },
     "@types/diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-4.0.2.tgz",
@@ -90,8 +176,7 @@
     "agent-base": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-5.1.1.tgz",
-      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g==",
-      "dev": true
+      "integrity": "sha512-TMeqbNl2fMW0nMjTEPOwe3J/PRFP4vqeoNuQMG0HlMrtm5QxKqdvAkZ1pRBQ/ulIyDD5Yq0nJ7YbdD8ey0TO3g=="
     },
     "ajv": {
       "version": "6.10.2",
@@ -547,6 +632,11 @@
         "xdg-basedir": "^3.0.0"
       }
     },
+    "cookie": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
+    },
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
@@ -591,7 +681,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -2074,7 +2163,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-4.0.0.tgz",
       "integrity": "sha512-zoDhWrkR3of1l9QAL8/scJZyLu8j/gBkcwcaQOZh7Gyh/+uJQzGVETdgT30akuwkpL8HTRfssqI3BZuV18teDg==",
-      "dev": true,
       "requires": {
         "agent-base": "5",
         "debug": "4"
@@ -2513,6 +2601,11 @@
         "yallist": "^2.1.2"
       }
     },
+    "lru_map": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/lru_map/-/lru_map-0.3.3.tgz",
+      "integrity": "sha1-tcg1G5Rky9dQM1p5ZQoOwOVhGN0="
+    },
     "lunr": {
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.8.tgz",
@@ -2640,8 +2733,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -3716,8 +3808,7 @@
     "tslib": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.10.0.tgz",
-      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ==",
-      "dev": true
+      "integrity": "sha512-qOebF53frne81cf0S9B41ByenJ3/IuH8yJKngAX35CmiZySA0khhkovshKK+jGCaMnVomla7gVlIcc3EvKPbTQ=="
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "dependencies": {
+    "@sentry/node": "^5.15.5",
     "@types/glob": "^7.1.1",
     "@types/puppeteer": "^2.0.1",
     "argparse": "^1.0.10",


### PR DESCRIPTION
When end-to-end tests are run in a pipeline – or, as in our main use case, in many pipelines over different projects – it is easy to miss failure.
A single missed failure doesn't (usually) hurt, but if there is a pattern of a flaky test (because of a problem with the test or the tested service, or both), then we want to know.
Sentry can already deal with errors and collate them, so add an option to use sentry.
If the `CI` environment variable is set and a sentry DSN is set, turn on sentry automatically (This enables Ops to configure the environment variable `SENTRY_DSN` and have reports show up automatically).
