### PR TITLE
Include assert_utils in doc

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ test:
 
 doc: *.js tsconfig.json
 	./node_modules/.bin/typedoc --out doc --noEmit --excludeNotExported --excludeNotDocumented --excludeExternals \
-		browser_utils.js email.js net_utils.js promise_utils.js utils.js
+		*.js
 
 lockserver-dev:
 	node_modules/.bin/nodemon lockserver/lockserver.js

--- a/output.js
+++ b/output.js
@@ -117,6 +117,7 @@ function logVerbose(config, message) {
 /**
  * Indent string
  * @param {number} n Levels of indentation
+ * @hidden
  */
 function indent(n) {
     return '  '.repeat(n);
@@ -129,6 +130,7 @@ function indent(n) {
  * diff.
  * @param {*} value Value to stringify
  * @returns {string}
+ * @hidden
  */
 function stringify(value, level = 0) {
     if (typeof value === 'string') return `"${value}"`;
@@ -194,6 +196,7 @@ function shouldShowDiff(err) {
  * @param {*} config The pentf configuration object.
  * @param {Error} err The error to generate the diff from
  * @returns {string}
+ * @hidden
  */
 function generateDiff(config, err) {
     assert(err);
@@ -249,6 +252,7 @@ function color(config, colorName, str) {
  * Format the error 
  * @param {*} config Penf config object
  * @param {Error} err Error object to format
+ * @hidden
  */
 function formatError(config, err) {
     let diff = '';
@@ -268,6 +272,7 @@ function formatError(config, err) {
  * Generate a string representation for a random value.
  *
  * @param {*} value A random value.
+ * @hidden
  */
 function valueRepr(value) {
     if (typeof value === 'symbol') {


### PR DESCRIPTION
Simply include every *.js file, and mark all pentf-internal methods as `@hidden` to avoid documenting them as part of the public API.
