### PR TITLE
Move assert* from utils into assert_utils

### DIFF
--- a/assert_utils.js
+++ b/assert_utils.js
@@ -8,6 +8,8 @@
 
 const assert = require('assert').strict;
 
+const {wait} = require('./utils');
+
 /**
 * Assert that a value is a Number or BigInt.
 * @param x {number|BigInt} The value to check.
@@ -74,10 +76,109 @@ function assertGreaterEqual(x, y, message = undefined) {
     assert(x >= y, `Expected ${x} >= ${y}.` + (message ? ' ' + message : ''));
 }
 
+
+/**
+ * Assert that a condition is eventually true.
+ *
+ * @example
+ * ```javascript
+ * let called = false;
+ * setTimeout(() => {called = true;}, 2000);
+ * await assertEventually(() => called);
+ * ```
+ * @param {() => any} testfunc The test function. Must return `true` to signal success.
+ * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {string?} message Error message shown if the condition never becomes true within the timeout.
+ * @param {number?} timeout How long to wait, in milliseconds.
+ * @param {number?} checkEvery Intervals between checks, in milliseconds.
+ * @param {boolean?} crashOnError `true` (default): A thrown error/exception is an immediate failure.
+ *                                `false`: A thrown error/exception is treated as if the test function returned false.
+ */
+async function assertEventually(testfunc,
+    {message='assertEventually failed', timeout=10000, checkEvery=200, crashOnError=true} = {}) {
+
+    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
+        if (crashOnError) {
+            const res = await testfunc();
+            if (res) return res;
+        } else {
+            let crashed = false;
+            let res;
+            try {
+                res = await testfunc();
+            } catch (e) {
+                crashed = true;
+            }
+            if (!crashed) return res;
+        }
+
+        await wait(checkEvery);
+    }
+    throw new Error(`${message} (waited ${timeout}ms)`);
+}
+
+/**
+ * Assert that an asynchronously evaluated condition is eventually true.
+ *
+ * @param {() => Promise<any>} testfunc The async test function. Must return `true` to signal success.
+ * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {string?} message Error message shown if the condition never becomes true within the timeout.
+ * @param {number?} timeout How long to wait, in milliseconds.
+ * @param {number?} checkEvery Intervals between checks, in milliseconds.
+ * @param {boolean?} crashOnError `true` (default): A thrown error/exception is an immediate failure.
+ *                                `false`: A thrown error/exception is treated as if the test function returned false.
+ */
+async function assertAsyncEventually(testfunc,
+    {message='assertAsyncEventually failed', timeout=10000, checkEvery=200, crashOnError=true} = {}) {
+
+    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
+        if (crashOnError) {
+            const res = await testfunc();
+            if (res) return res;
+        } else {
+            let crashed = false;
+            let res;
+            try {
+                res = await testfunc();
+            } catch (e) {
+                crashed = true;
+            }
+            if (!crashed) return res;
+        }
+
+        await wait(checkEvery);
+    }
+    throw new Error(`${message} (waited ${timeout}ms)`);
+}
+
+/**
+ * Assert that a condition remains true for the whole timeout.
+ *
+ * @param {() => any} testfunc The test function. Must return `true` to signal success.
+ * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}}  [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {string?} message Error message shown if the testfunc fails.
+ * @param {number?} timeout How long to wait, in milliseconds.
+ * @param {number?} checkEvery Intervals between checks, in milliseconds.
+*/
+async function assertAlways(testfunc, {message='assertAlways failed', timeout=10000, checkEvery=200} = {}) {
+    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
+        const res = testfunc();
+        if (!res) {
+            throw new Error(`${message} (after ${timeout - remaining}ms)`);
+        }
+
+        await wait(checkEvery);
+    }
+}
+
+
 module.exports = {
-    assertLess,
-    assertLessEqual,
+    assertAlways,
+    assertAsyncEventually,
+    assertEventually,
     assertGreater,
     assertGreaterEqual,
+    assertLess,
+    assertLessEqual,
     assertNumeric,
 };

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -11,7 +11,8 @@ const path = require('path');
 const {promisify} = require('util');
 const tmp = require('tmp-promise');
 
-const {assertAsyncEventually, wait, remove} = require('./utils');
+const {assertAsyncEventually} = require('./assert_utils');
+const {wait, remove} = require('./utils');
 
 let tmp_home;
 

--- a/tests/selftest_assertEventually.js
+++ b/tests/selftest_assertEventually.js
@@ -1,6 +1,6 @@
 const assert = require('assert').strict;
 
-const {assertEventually} = require('../utils');
+const {assertEventually} = require('../assert_utils');
 
 async function run() {
     await assert.rejects(assertEventually(() => false, {timeout: 10, checkEvery: 1, message: 'Never changed'}), {

--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 
+const {assertEventually} = require('../assert_utils');
 const {assertNotXPath, clickXPath, clickText, waitForText, closePage, newPage} = require('../browser_utils');
-const {assertEventually} = require('../utils');
 
 async function run(config) {
     const page = await newPage(config);

--- a/tests/selftest_clickSelector.js
+++ b/tests/selftest_clickSelector.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 
 const {clickSelector, closePage, newPage} = require('../browser_utils');
-const {assertEventually} = require('../utils');
+const {assertEventually} = require('../assert_utils');
 
 async function run(config) {
     const page = await newPage(config);

--- a/tests/selftest_clickTestId.js
+++ b/tests/selftest_clickTestId.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 
 const {closePage, newPage, clickTestId} = require('../browser_utils');
-const {assertEventually} = require('../utils');
+const {assertEventually} = require('../assert_utils');
 
 async function run(config) {
     const page = await newPage(config);

--- a/tests/selftest_speedupTimeouts.js
+++ b/tests/selftest_speedupTimeouts.js
@@ -1,7 +1,7 @@
 const assert = require('assert').strict;
 
 const {speedupTimeouts, restoreTimeouts, closePage, newPage} = require('../browser_utils');
-const {assertAlways, assertEventually} = require('../utils');
+const {assertAlways, assertEventually} = require('../assert_utils');
 
 async function run(config) {
     const page = await newPage(config);

--- a/utils.js
+++ b/utils.js
@@ -155,98 +155,40 @@ function localIso8601(date) {
     );
 }
 
-/**
- * Assert that a condition is eventually true.
- *
- * @example
- * ```javascript
- * let called = false;
- * setTimeout(() => {called = true;}, 2000);
- * await assertEventually(() => called);
- * ```
- * @param {() => any} testfunc The test function. Must return `true` to signal success.
- * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
- * @param {string?} message Error message shown if the condition never becomes true within the timeout.
- * @param {number?} timeout How long to wait, in milliseconds.
- * @param {number?} checkEvery Intervals between checks, in milliseconds.
- * @param {boolean?} crashOnError `true` (default): A thrown error/exception is an immediate failure.
- *                                `false`: A thrown error/exception is treated as if the test function returned false.
- */
-async function assertEventually(testfunc,
-    {message='assertEventually failed', timeout=10000, checkEvery=200, crashOnError=true} = {}) {
-
-    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
-        if (crashOnError) {
-            const res = await testfunc();
-            if (res) return res;
-        } else {
-            let crashed = false;
-            let res;
-            try {
-                res = await testfunc();
-            } catch (e) {
-                crashed = true;
-            }
-            if (!crashed) return res;
-        }
-
-        await wait(checkEvery);
+function assertEventually(...args) {
+    // Deprecated here; will warn in the future, and eventually be removed
+    const assert_utils = require('./assert_utils');
+    if (process.env.PENTF_FUTURE_DEPRECATIONS) {
+        // eslint-disable-next-line no-console
+        console.log(); // new line (we can't call output.log here)
+        // eslint-disable-next-line no-console
+        console.trace('utils.assertEventually has been moved to assert_utils');
     }
-    throw new Error(`${message} (waited ${timeout}ms)`);
+    return assert_utils.assertEventually(...args);
 }
 
-/**
- * Assert that an asynchronously evaluated condition is eventually true.
- *
- * @param {() => Promise<any>} testfunc The async test function. Must return `true` to signal success.
- * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
- * @param {string?} message Error message shown if the condition never becomes true within the timeout.
- * @param {number?} timeout How long to wait, in milliseconds.
- * @param {number?} checkEvery Intervals between checks, in milliseconds.
- * @param {boolean?} crashOnError `true` (default): A thrown error/exception is an immediate failure.
- *                                `false`: A thrown error/exception is treated as if the test function returned false.
- */
-async function assertAsyncEventually(testfunc,
-    {message='assertAsyncEventually failed', timeout=10000, checkEvery=200, crashOnError=true} = {}) {
-
-    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
-        if (crashOnError) {
-            const res = await testfunc();
-            if (res) return res;
-        } else {
-            let crashed = false;
-            let res;
-            try {
-                res = await testfunc();
-            } catch (e) {
-                crashed = true;
-            }
-            if (!crashed) return res;
-        }
-
-        await wait(checkEvery);
+function assertAsyncEventually(...args) {
+    // Deprecated here; will warn in the future, and eventually be removed
+    const assert_utils = require('./assert_utils');
+    if (process.env.PENTF_FUTURE_DEPRECATIONS) {
+        // eslint-disable-next-line no-console
+        console.log(); // new line (we can't call output.log here)
+        // eslint-disable-next-line no-console
+        console.trace('utils.assertAsyncEventually has been moved to assert_utils');
     }
-    throw new Error(`${message} (waited ${timeout}ms)`);
+    return assert_utils.assertAsyncEventually(...args);
 }
 
-/**
- * Assert that a condition remains true for the whole timeout.
- *
- * @param {() => any} testfunc The test function. Must return `true` to signal success.
- * @param {{message?: string, timeout?: number, checkEvery?: number, crashOnError?: boolean}}  [__namedParameters] Options (currently not visible in output due to typedoc bug)
- * @param {string?} message Error message shown if the testfunc fails.
- * @param {number?} timeout How long to wait, in milliseconds.
- * @param {number?} checkEvery Intervals between checks, in milliseconds.
-*/
-async function assertAlways(testfunc, {message='assertAlways failed', timeout=10000, checkEvery=200} = {}) {
-    for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
-        const res = testfunc();
-        if (!res) {
-            throw new Error(`${message} (after ${timeout - remaining}ms)`);
-        }
-
-        await wait(checkEvery);
+function assertAlways(...args) {
+    // Deprecated here; will warn in the future, and eventually be removed
+    const assert_utils = require('./assert_utils');
+    if (process.env.PENTF_FUTURE_DEPRECATIONS) {
+        // eslint-disable-next-line no-console
+        console.log(); // new line (we can't call output.log here)
+        // eslint-disable-next-line no-console
+        console.trace('utils.assertAlways has been moved to assert_utils');
     }
+    return assert_utils.assertAlways(...args);
 }
 
 function cmp(a, b) {


### PR DESCRIPTION
For historical reasons, the `utils` module is a grab bag of various helper functions.
Now that we have a dedicated module `assert_utils` for assert helpers, move all these assertion helpers there.
