### PR TITLE
Add an example test for access frames

### DIFF
--- a/tests/browser_frames.js
+++ b/tests/browser_frames.js
@@ -1,0 +1,26 @@
+const {assertEventually} = require('../assert_utils');
+const {closePage, newPage, waitForText} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config, ['--disable-features=IsolateOrigins,site-per-process']);
+    await page.setContent(`
+        This is a webpage which loads an iframe
+        <script>
+        const iframe = document.createElement('iframe');
+        iframe.src = 'https://example.org/';
+        document.body.appendChild(iframe);
+        </script>`);
+
+    const exampleFrame = await assertEventually(
+        () => page.frames().find(frame => frame.url().startsWith('https://example.org/'))
+    );
+    await waitForText(exampleFrame, 'Example Domain');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Accessing content in iframes at other domains',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Unfortunately, accessing frames of another origin is anything but trivial with Chrome & puppeteer. It's possible, but nothing works by default.

By simply passing in `['--disable-features=IsolateOrigins,site-per-process']` as Chrome args (`IsolateOrigins` may even be optional), everything goes back to working.
