### PR TITLE
Add a lazyAssert helper function

### DIFF
--- a/assert_utils.js
+++ b/assert_utils.js
@@ -171,6 +171,20 @@ async function assertAlways(testfunc, {message='assertAlways failed', timeout=10
     }
 }
 
+/**
+ * Assert function with a message that is generated on demand.
+ * @example
+ * ```javascript
+ * lazyAssert(obj?.foo?.bar, () => `Object is missing foo.bar. Full object: ${JSON.stringify(obj)}`);
+ * ```
+ * @param {boolean} value The value to be asserted to be true.
+ * @param {() => string} makeMessage Function to generate the error message, should the value be false.
+*/
+function lazyAssert(value, makeMessage) {
+    if (! value) {
+        assert(value, makeMessage());
+    }
+}
 
 module.exports = {
     assertAlways,
@@ -181,4 +195,5 @@ module.exports = {
     assertLess,
     assertLessEqual,
     assertNumeric,
+    lazyAssert,
 };

--- a/tests/selftest_lazy_assert.js
+++ b/tests/selftest_lazy_assert.js
@@ -1,0 +1,19 @@
+const assert = require('assert').strict;
+
+const {lazyAssert} = require('../assert_utils');
+
+async function run() {
+    let executed = false;
+    lazyAssert(true, () => {executed = true; return 'executed';});
+    assert(!executed);
+    assert.throws(
+        () => lazyAssert(false, () => {executed = true; return 'generated';}),
+        {message: 'generated'});
+    assert(executed);
+}
+
+module.exports = {
+    description: 'assert_utils.lazyAssert helper function',
+    run,
+    resources: [],
+};


### PR DESCRIPTION
Sometimes, we want an assertion message to be very helpful, and doing so requires expensive calls (usually `JSON.stringify`, but may also other data grovelling or reading from a file).
If the assertion almos never fails, then it would be a huge waste to calculate the error message on every call.

At first, I thought this function would be too trivial to be included in pentf.
However, we already have 3 copies with differing implementations.

Add it as an official function in assert_utils.
In the future, we may add an async variant, or the ability to wrap arbitrary other assertion functions.
