### PR TITLE
assert_utils: +assertIncludes

### DIFF
--- a/assert_utils.js
+++ b/assert_utils.js
@@ -76,6 +76,30 @@ function assertGreaterEqual(x, y, message = undefined) {
     assert(x >= y, `Expected ${x} >= ${y}.` + (message ? ' ' + message : ''));
 }
 
+/**
+* Assert that a string is included in another, or object is included in an array.
+*
+* @example
+* ```javascript
+* assertIncludes('foobar', 'foo');
+* assertIncludes([9, 5, 3], 5);
+* ```
+* @param {string|array} haystack The thing to search in.
+* @param {string|array} needle The thing to search for.
+* @param {string?} message Optional error message if the assertion does not hold.
+*/
+function assertIncludes(haystack, needle, message = undefined) {
+    lazyAssert(
+        haystack.includes, () => `Haystack object ${haystack} does not have an includes method`);
+
+    lazyAssert(
+        haystack.includes(needle),
+        () => (
+            `Expected ${JSON.stringify(haystack)} to include ${JSON.stringify(needle)}.` +
+            (message ? ' ' + message : '')
+        )
+    );
+}
 
 /**
  * Assert that a condition is eventually true.
@@ -192,6 +216,7 @@ module.exports = {
     assertEventually,
     assertGreater,
     assertGreaterEqual,
+    assertIncludes,
     assertLess,
     assertLessEqual,
     assertNumeric,

--- a/tests/selftest_assertIncludes.js
+++ b/tests/selftest_assertIncludes.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+
+const {assertIncludes} = require('../assert_utils');
+
+async function run() {
+    assertIncludes('& foobar', 'foo');
+    assertIncludes([9, 5, 4], 5);
+
+    assert.throws(
+        () => assertIncludes('haystack', 'foo'),
+        {message: 'Expected "haystack" to include "foo".'});
+    assert.throws(
+        () => assertIncludes([2, 3], 4, 'missing'),
+        {message: 'Expected [2,3] to include 4. missing'});
+    assert.throws(
+        () => assertIncludes(42, 'foo', 'message not output because of internal error'),
+        {message: 'Haystack object 42 does not have an includes method'});
+
+}
+
+module.exports = {
+    description: 'assert_utils.assertIncludes',
+    run,
+    resources: [],
+};


### PR DESCRIPTION
Add a helper function to get a better message when checking for the presence a substring or an array element.
