### PR TITLE
Make logged error stack visually more pleasing

### DIFF
--- a/output.js
+++ b/output.js
@@ -260,8 +260,18 @@ function formatError(config, err) {
         diff += generateDiff(config, err);
     }
 
-    return diff + err.stack
-        .split('\n')
+    const stack = errorstacks.parseStackTrace(err.stack)
+        .map(frame => {
+            if (frame.name) {
+                return color(config, 'dim', `    at ${frame.name} (`) + color(config, 'cyan', frame.fileName) + color(config, 'dim', `:${frame.line}:${frame.column})`);
+            } else {
+                // Internal native code in node
+                return color(config, 'dim', frame.raw);
+            }
+        });
+
+    const message = `${err.name}: ${err.message}`;
+    return '\n' + diff + ([message, ...stack])
         // Indent stack trace
         .map(line => '  ' + line)
         .join('\n');

--- a/output.js
+++ b/output.js
@@ -4,6 +4,7 @@ const assert = require('assert').strict;
 const readline = require('readline');
 const diff = require('diff');
 const kolorist = require('kolorist');
+const errorstacks = require('errorstacks');
 
 const utils = require('./utils');
 const {resultCountString} = require('./results');
@@ -249,6 +250,21 @@ function color(config, colorName, str) {
 }
 
 /**
+ * Mark a string as a link for terminals that support this (GNOME Terminal)
+ * @param {*} config 
+ * @param {string} text 
+ * @param {string} target 
+ * @hidden
+ */
+function link(config, text, target) {
+    if (!config.colors) {
+        return text;
+    }
+
+    return kolorist.link(text, target);
+}
+
+/**
  * Format the error 
  * @param {*} config Penf config object
  * @param {Error} err Error object to format
@@ -263,7 +279,8 @@ function formatError(config, err) {
     const stack = errorstacks.parseStackTrace(err.stack)
         .map(frame => {
             if (frame.name) {
-                return color(config, 'dim', `    at ${frame.name} (`) + color(config, 'cyan', frame.fileName) + color(config, 'dim', `:${frame.line}:${frame.column})`);
+                const location = link(config, frame.fileName, `file://${frame.fileName}`);
+                return color(config, 'dim', `    at ${frame.name} (`) + color(config, 'cyan', location) + color(config, 'dim', `:${frame.line}:${frame.column})`);
             } else {
                 // Internal native code in node
                 return color(config, 'dim', frame.raw);

--- a/package-lock.json
+++ b/package-lock.json
@@ -920,6 +920,11 @@
       "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
       "dev": true
     },
+    "errorstacks": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/errorstacks/-/errorstacks-1.1.5.tgz",
+      "integrity": "sha512-ANB+6I4d0oULE2lEEXOJNvH0mpZ5YhFUhzEhJRB2v+FJzmJYRFei2fHS755gsJ+F20exLVNS2ND9xvZ2oYGhvQ=="
+    },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "diff": "^4.0.2",
     "emailjs-imap-client": "^3.0.7",
     "emailjs-mime-parser": "^2.0.5",
+    "errorstacks": "^1.1.5",
     "form-data": "^2.3.3",
     "glob": "^7.1.6",
     "he": "^1.2.0",


### PR DESCRIPTION
While debugging a test-failure in [preact-devtools](https://github.com/preactjs/preact-devtools) I noticed that it was hard for me to quickly "scan" over the error output. I always have to concentrate to focus on the relevant information of the stack trace.

With this PR I've tried to introduce a little bit of visual hierarchy. The location of the current frame is highlighted as I've always perceived it as the most important information of the stack trace.

Verified with the output generated by [jest](https://github.com/facebook/jest) and they do the exact same thing and apply the same coloring.

To make life easier I've also marked it as a link. Not all terminals support this feature, but the GNOME Terminal specifically does. Haven't checked others. It allows users to simply click on the link to open the file directly in their IDE/Editor.

Let me know what you think!

Before:

![Screenshot from 2020-06-07 18-25-30](https://user-images.githubusercontent.com/1062408/83974273-87a97780-a8ec-11ea-96af-ff9d9888f1c2.png)

After:

![Screenshot from 2020-06-07 18-40-02](https://user-images.githubusercontent.com/1062408/83974558-782b2e00-a8ee-11ea-88a0-df7eabb29cde.png)

And for completeness sake the non-colored version:

![Screenshot from 2020-06-07 18-25-54](https://user-images.githubusercontent.com/1062408/83974281-9b54de00-a8ec-11ea-90f9-e27d14b4e770.png)
