### PR TITLE
Add optional code-frame to show error location

### DIFF
--- a/output.js
+++ b/output.js
@@ -322,9 +322,10 @@ function genCodeFrame(config, content, lineNum, columnNum, before, after) {
  * Format the error 
  * @param {*} config Penf config object
  * @param {Error} err Error object to format
+ * @returns {Promise<string>}
  * @hidden
  */
-function formatError(config, err) {
+async function formatError(config, err) {
     let diff = '';
     if (shouldShowDiff(err)) {
         diff += generateDiff(config, err);
@@ -356,7 +357,7 @@ function formatError(config, err) {
     let codeFrame = '';
     if (nearestFrame) {
         const { fileName, line, column } = nearestFrame;
-        const content = fs.readFileSync(fileName, 'utf-8');
+        const content = await fs.promises.readFile(fileName, 'utf-8');
         codeFrame = `\n${genCodeFrame(config, content, line - 1, column, 2, 3)}\n`;
     }
 

--- a/output.js
+++ b/output.js
@@ -304,13 +304,13 @@ function genCodeFrame(config, content, lineNum, columnNum, before, after) {
     const lines = content.split('\n');
     const startLine = Math.max(0, lineNum - before);
     const endLine = Math.min(lines.length - 1, lineNum + after);
-    const maxDigits = String(endLine).length;
-    const padding = ' '.repeat(maxDigits);
+    const maxChars = String(endLine).length;
+    const padding = ' '.repeat(maxChars);
 
     return lines.slice(startLine, endLine)
         .map((line, i) => {
             const n = startLine + i;
-            const currentLine = (padding + n).slice(-maxDigits);
+            const currentLine = (padding + n).slice(-maxChars);
 
             const normalized = tabs2Spaces(line);
             if (n === lineNum) {

--- a/output.js
+++ b/output.js
@@ -302,12 +302,17 @@ function genCodeFrame(config, content, lineNum, columnNum, before, after) {
             const n = startLine + i;
             const currentLine = (padding + n).slice(-maxDigits);
 
+            const normalized = tabs2Spaces(line);
             if (n === lineNum) {
                 const marker = color(config, 'bold-red', '>');
-                const formatted = `${marker} ${currentLine} | ${tabs2Spaces(line)}`;
-                return formatted + `\n  ${padding} ${color(config, 'dim', '|')} ${'  '.repeat(columnNum)}${color(config, 'bold-red', '^')}`;
+                const formatted = `${marker} ${currentLine} | ${normalized}`;
+                
+                // Account for possible tab indention
+                const count = (line.length - normalized.length) + columnNum - 1;
+
+                return formatted + `\n  ${padding} ${color(config, 'dim', '|')} ${' '.repeat(count)}${color(config, 'bold-red', '^')}`;
             } else {
-                return color(config, 'gray', `  ${currentLine} | ${tabs2Spaces(line)}`);
+                return color(config, 'gray', `  ${currentLine} | ${normalized}`);
             }
         })
         .join('\n');

--- a/output.js
+++ b/output.js
@@ -348,7 +348,7 @@ function formatError(config, err) {
                 return color(config, 'dim', `  at ${frame.name} (`) + color(config, 'cyan', location) + color(config, 'dim', `:${frame.line}:${frame.column})`);
             } else {
                 // Internal native code in node (or CI system)
-                return color(config, 'dim', frame.raw);
+                return color(config, 'dim', `  ${frame.raw.trim()}`);
             }
         });
 

--- a/runner.js
+++ b/runner.js
@@ -88,7 +88,7 @@ async function run_task(config, task) {
                 output.log(
                     config,
                     `${label} test case ${name} at ${utils.localIso8601()}:\n` +
-                    `${output.formatError(config, e)}\n`);
+                    `${await output.formatError(config, e)}\n`);
 
                 if (config.sentry) {
                     const Sentry = require('@sentry/node');


### PR DESCRIPTION
This PR adds a code-frame to directly show where the error occurred in relation to the original source code. It's optional and will only be present if the error was thrown by user code. 

Colors:

![Screenshot from 2020-06-08 00-19-25](https://user-images.githubusercontent.com/1062408/83981439-14205e00-a91e-11ea-8abb-ad1bdc65787d.png)

No colors:

![Screenshot from 2020-06-08 00-24-44](https://user-images.githubusercontent.com/1062408/83981486-81cc8a00-a91e-11ea-9f75-efb9d802992c.png)

