### PR TITLE
net_utils: Support following redirects with cookies

### DIFF
--- a/curl_command.js
+++ b/curl_command.js
@@ -33,10 +33,6 @@ async function makeCurlCommand(options, url) {
         curl_command += ' -k';
     }
 
-    if (options.redirect === 'follow') {
-        curl_command += ' -L';
-    }
-
     if (options.curl_include_headers) {
         curl_command += ' -i';
     }


### PR DESCRIPTION
Before this, cookies set during redirects did not land in the cookie jar.
Implement redirect following ourselves in order to handle the cookies.

Also, make sure we don't mutate `init` for the caller, as we are writing a lot in there.

As an added benefit, we'll see all requests in the curl output, which is much more sensible for virtually all HTTP-level tests.
