### PR TITLE
net_utils: Fix fetch without a third argument

### DIFF
--- a/net_utils.js
+++ b/net_utils.js
@@ -40,8 +40,9 @@ const {readFile} = require('./utils');
  *               The response will have a utility function `async getCookieValue(name)` to quickly retrieve a cookie value from the jar.
  */
 async function fetch(config, url, init) {
+    if (!init) init = {};
     const redirect = init._redirect || init.redirect || 'manual';
-    init = init ? {...init} : {};
+    init = {...init}; // make sure we don't change the object directly
     init._redirect = redirect;
     init.redirect = 'manual';
 

--- a/tests/selftest_fetch.js
+++ b/tests/selftest_fetch.js
@@ -114,11 +114,17 @@ async function run(config) {
     });
     const url = `http://localhost:${port}/`;
 
-    let response = await fetch(config, url, {cookieJar: 'create'});
+    // Start with a very simple request
+    let response = await fetch(config, url);
+    assert.equal(response.status, 200);
+
+    // Create a cookie jar
+    response = await fetch(config, url, {cookieJar: 'create'});
     assert.equal(response.status, 200);
     assert.equal(await response.getCookieValue('visitCount'), '1');
     const cookieJar = response.cookieJar;
 
+    // Use an existing cookie jar
     response = await fetch(config, url, {cookieJar});
     assert.equal(response.status, 200);
     assert.equal(await response.getCookieValue('visitCount'), '2');


### PR DESCRIPTION
In my attempts to optimize the function for very complicated calls, I forgot the simplest one :(
