### PR TITLE
Add a helper function to type text

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,10 @@ If the tests run quick and a remote system is slow, the browser UI may not updat
 
 **Use**: `page.waitForSelector('foo')`
 
+**Avoid**: `page.type('#foo', 'bar')`
+
+**Use**: `browser_utils.typeSelector(page, '#foo', 'bar')`
+
 ### Make sure you start waiting _early_
 
 Make sure that an action you are waiting on has not already happend. In particular, `await page.waitForNavigation()` calls should probably be replaced by checks for the new page.

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -536,7 +536,7 @@ async function clickText(page, text, {timeout=30000, checkEvery=200, elementXPat
  * @param {number?} timeout How long to wait, in milliseconds.
  * @param {number?} checkEvery Intervals between checks, in milliseconds. (default: 200ms)
  * @param {string?} extraMessage Optional error message shown if the element is not visible in time.
- * @param {boolean?} visibale Optional check if element is visible (default: true)
+ * @param {boolean?} visible Optional check if element is visible (default: true)
  */
 async function clickNestedText(page, textOrRegExp, {timeout=30000, checkEvery=200, extraMessage=undefined, visible=true}={}) {
     if (typeof textOrRegExp === 'string') {
@@ -640,6 +640,20 @@ async function clickTestId(page, testId, {extraMessage=undefined, timeout=30000,
     const extraMessageRepr = extraMessage ? `. ${extraMessage}` : '';
     const message = `Failed to find${visible ? ' visible' : ''} element with data-testid "${testId}" within ${timeout}ms${extraMessageRepr}`;
     return await clickXPath(page, xpath, {timeout, message, visible});
+}
+
+/**
+ * Type text into an element identified by a query selector.
+ *
+ * @param {import('puppeteer').Page} page puppeteer page object.
+ * @param {string} selector selector [CSS selector](https://www.w3.org/TR/2018/REC-selectors-3-20181106/#selectors) (aka query selector) of the element to type in.
+ * @param {{message?: string, timeout?: number}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {number?} timeout How long to wait, in milliseconds.
+ * @param {string?} message Message shown if the element can not be found.
+ */
+async function typeSelector(page, selector, text, {message=undefined, timeout=30000}={}) {
+    const el = await waitForVisible(page, selector, {timeout, message});
+    await el.type(text);
 }
 
 /**
@@ -842,6 +856,7 @@ module.exports = {
     restoreTimeouts,
     setLanguage,
     speedupTimeouts,
+    typeSelector,
     waitForTestId,
     waitForText,
     waitForVisible,

--- a/tests/demo_browser_input_type.js
+++ b/tests/demo_browser_input_type.js
@@ -1,0 +1,25 @@
+const {closePage, newPage} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.setContent(`
+        <script>
+        setTimeout(() => {
+            const input = document.createElement('input');
+            input.setAttribute('id', 'input');
+            document.body.appendChild(input);
+        }, 1000);
+        </script>`);
+    // THIS WILL FAIL – Do not use! See selftest_typeSelector for a working equivalent
+    await page.type('#input', 'foobar'); // WRONG CODE
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Demonstration of an anti-pattern when typing into text fields',
+    resources: [],
+    run,
+    skip: () => !process.env.PENTF_DEMO && 'PENTF_DEMO environment variable not set',
+    expectedToFail: 'Will crash',
+};

--- a/tests/selftest_typeSelector.js
+++ b/tests/selftest_typeSelector.js
@@ -1,0 +1,27 @@
+const assert = require('assert').strict;
+
+const {closePage, newPage, typeSelector} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.setContent(`
+        <script>
+        setTimeout(() => {
+            const input = document.createElement('input');
+            input.setAttribute('id', 'input');
+            document.body.appendChild(input);
+        }, 1000);
+        </script>`);
+    await typeSelector(page, '#input', 'foobar');
+
+    const value = await page.evaluate(() => document.querySelector('#input').value);
+    assert.equal(value, 'foobar');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'browser_utils.typeSelector to type text into an <input> element',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Typing text into an `<input>` or `<textarea>` should be really simple, but sadly puppeteer's `page.type()` runs immediately, which is a recipe for flakiness.
Add a very simple alternative, a demonstration of why the alternative fails, a selftest, and document it.
