### PR TITLE
Add support for forwarding browser console messages

### DIFF
--- a/browser_console.js
+++ b/browser_console.js
@@ -45,10 +45,10 @@ function parseConsoleArg(value) {
  * are lossy. They turn Error objects into `{}` and `null` to `undefined`.
  * The passed "preview" object is incomplete and truncates all data for nested
  * objects or other complex values.
- * 
+ *
  * The only way to keep the data intact is to use a custom serialization format
  * and pass it around as a string.
- * 
+ *
  * @param {import('puppeteer').Page} page
  */
 async function patchBrowserConsole(page) {
@@ -120,6 +120,10 @@ async function patchBrowserConsole(page) {
         for (const key in console) {
             native[key] = console[key];
             console[key] = (...args) => {
+                if (key === 'trace') {
+                    const stack = new Error().stack.split('\n').slice(2).join('\n');
+                    args = ['\n' + stack, ...args];
+                }
                 native[key].call(null, JSON.stringify(args.map(arg => serialize(arg))));
             };
         }

--- a/browser_console.js
+++ b/browser_console.js
@@ -1,0 +1,132 @@
+/**
+ * Reconstruct original types from serialized message
+ * @param {*} value
+ */
+function parseConsoleArg(value) {
+    if (Array.isArray(value)) {
+        return value.map(item => parseConsoleArg(item));
+    } else if (typeof value === 'object') {
+        if (value.__pentf_serialized) {
+            if (value.type === 'null') {
+                return null;
+            } else if (value.type === 'undefined') {
+                return undefined;
+            } else if (value.type === 'Error') {
+                const err = new Error(value.message);
+                err.stack = value.stack;
+                return err;
+            } else if (value.type === 'Set') {
+                return new Set(value.items.map(item => parseConsoleArg(item)));
+            } else if (value.type === 'Map') {
+                return new Map(
+                    value.items.map(item => {
+                        return [parseConsoleArg(item[0]), parseConsoleArg(item[1])];
+                    })
+                );
+            } else if (value.type === 'Function') {
+                // Mirror node output format
+                return !value.name ? '[Function (anonymous)]' : `[Function: ${value.name}]`;
+            }
+        }
+
+        let out = {};
+        for (const key in value) {
+            out[key] = parseConsoleArg(value[key]);
+        }
+        return out;
+    }
+
+    return value;
+}
+
+/**
+ * Serialize console arguments and send them to puppeteer. Unfortunately for
+ * us the native serialization methods for JSHandle objects from puppeteer
+ * are lossy. They turn Error objects into `{}` and `null` to `undefined`.
+ * The passed "preview" object is incomplete and truncates all data for nested
+ * objects or other complex values.
+ * 
+ * The only way to keep the data intact is to use a custom serialization format
+ * and pass it around as a string.
+ * 
+ * @param {import('puppeteer').Page} page
+ */
+async function patchBrowserConsole(page) {
+    await page.evaluate(() => {
+        const seen = new Set();
+
+        function serialize(value) {
+            if (seen.has(value)) {
+                return '[[Circular]]';
+            }
+
+            if (Array.isArray(value)) {
+                seen.add(value);
+                return value.map(x => serialize(x));
+            } else if (value === undefined) {
+                return {
+                    __pentf_serialized: true,
+                    type: 'undefined',
+                };
+            } else if (typeof value === 'object') {
+                if (value === null) {
+                    return {
+                        __pentf_serialized: true,
+                        type: 'null',
+                    };
+                } else if (value instanceof Error) {
+                    // TODO: check fur custom keys
+                    return {
+                        __pentf_serialized: true,
+                        type: 'Error',
+                        message: value.message,
+                        stack: value.stack,
+                    };
+                } else if (value instanceof Set) {
+                    return {
+                        __pentf_serialized: true,
+                        type: 'Set',
+                        items: Array.from(value).map(item => serialize(item)),
+                    };
+                } else if (value instanceof Map) {
+                    return {
+                        __pentf_serialized: true,
+                        type: 'Map',
+                        items: Array.from(value.entries()).map(entry => {
+                            return [serialize(entry[0]), serialize(entry[1])];
+                        }),
+                    };
+                }
+
+                seen.add(value);
+                let out = {};
+                Object.keys(value).forEach(key => {
+                    out[key] = serialize(value[key]);
+                });
+
+                return out;
+            } else if (typeof value === 'function') {
+                return {
+                    __pentf_serialized: true,
+                    type: 'Function',
+                    name: value.name,
+                };
+            }
+
+            return value;
+        }
+
+        const native = {};
+        for (const key in console) {
+            native[key] = console[key];
+            console[key] = (...args) => {
+                native[key].call(null, JSON.stringify(args.map(arg => serialize(arg))));
+            };
+        }
+    });
+}
+
+module.exports = {
+    parseConsoleArg,
+    patchBrowserConsole,
+};

--- a/browser_console.js
+++ b/browser_console.js
@@ -116,7 +116,7 @@ function serialize(value, seen) {
  */
 async function forwardBrowserConsole(page) {
     // The stack is not present on the trace method, so we need to patch it in
-    await page.evaluate((fn) => {
+    await page.evaluateOnNewDocument((fn) => {
         const serialize = new Function(`return ${fn}`)();
         const native = {};
         native.trace = console.trace;

--- a/browser_console.js
+++ b/browser_console.js
@@ -59,6 +59,8 @@ function serialize(value, seen) {
     } else if (value === null) {
         return null;
     } else if (typeof value === 'object') {
+        seen.add(value);
+
         if (value instanceof Error) {
             // TODO: check fur custom keys
             return {
@@ -83,7 +85,6 @@ function serialize(value, seen) {
             };
         }
 
-        seen.add(value);
         let out = {};
         Object.keys(value).forEach(key => {
             out[key] = serialize(value[key], seen);

--- a/browser_console.js
+++ b/browser_console.js
@@ -128,6 +128,9 @@ async function forwardBrowserConsole(page) {
     }, serialize.toString());
 
     page.on('console', async message => {
+        let resolve;
+        page._logs.push(new Promise(r => resolve = r));
+
         let type = message.type();
         // Correct log type for warning messages
         type = type === 'warning' ? 'warn' : type;
@@ -150,6 +153,8 @@ async function forwardBrowserConsole(page) {
             }
         } catch (err) {
             console.log(err);
+        } finally {
+            resolve();
         }
     });
 }

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -152,8 +152,15 @@ async function newPage(config, chrome_args=[]) {
             let type = message.type();
             // Correct log type for warning messages
             type = type === 'warning' ? 'warn' : type;
-            
-            const args = JSON.parse(message._text).map(arg => parseConsoleArg(arg));
+     
+            let args = [];
+            try {
+                args = JSON.parse(message._text).map(arg => parseConsoleArg(arg));
+            } catch(err) {
+                // Messages originating from browser extensions bypass our
+                // patched console, so we'll just print the raw value.
+                args = [message._text];
+            }
             if (type === 'trace') {
                 console.log(`Trace: ${args[1] || ''}${args[0]}`);
             } else {

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -154,7 +154,11 @@ async function newPage(config, chrome_args=[]) {
             type = type === 'warning' ? 'warn' : type;
             
             const args = JSON.parse(message._text).map(arg => parseConsoleArg(arg));
-            console[type].apply(console, args);
+            if (type === 'trace') {
+                console.log(`Trace: ${args[1] || ''}${args[0]}`);
+            } else {
+                console[type].apply(console, args);
+            }
         });
     }
 

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -146,6 +146,7 @@ async function newPage(config, chrome_args=[]) {
         await Promise.all(targets.map(t => configureDevtools(t)));
     }
 
+    page._logs = [];
     if (config.forward_console) {
         await forwardBrowserConsole(page);
     }
@@ -163,6 +164,9 @@ async function newPage(config, chrome_args=[]) {
  * @param {import('puppeteer').Page} page puppeteer page object returned by `newPage`.
  */
 async function closePage(page) {
+    // Wait for all pending logging tasks to finish before closing browser
+    await Promise.all(page._logs);
+
     if (page._pentf_browser_pages) {
         remove(page._pentf_browser_pages, p => p === page);
     }

--- a/config.js
+++ b/config.js
@@ -233,6 +233,10 @@ function parseArgs(options) {
         defaultValue: [],
         metavar: 'EXTENSION_DIR',
     });
+    puppeteer_group.addArgument(['--forward-console'], {
+        help: 'Forward browser console logs',
+        action: 'storeTrue',
+    });
 
     const runner_group = parser.addArgumentGroup({title: 'Test runner'});
     runner_group.addArgument(['-C', '--concurrency'], {

--- a/tests/selftest_console.js
+++ b/tests/selftest_console.js
@@ -47,6 +47,9 @@ async function run(config) {
             console.log(() => null);
             console.log(function foo() {});
             console.log(class Foo {});
+
+            console.trace();
+            console.trace('bar');
         }
         foo();
     });

--- a/tests/selftest_console.js
+++ b/tests/selftest_console.js
@@ -1,0 +1,62 @@
+const {closePage, newPage} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage({...config, forward_console: true});
+    await page.evaluate(() => {
+        function foo() {
+            console.log([
+                [123, new Error('foo')],
+                {
+                    foo: {
+                        bar: {
+                            bob: {
+                                boof: {
+                                    baz: {
+                                        sha: {
+                                            fasd: {
+                                                asd: 123,
+                                            },
+                                        },
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+                null,
+                undefined,
+                'foo',
+                new Error('fail'),
+            ]);
+
+            console.log([{'foo': null}]);
+
+            // Circular
+            const a = {foo: null};
+            a.foo = a;
+            console.log(a);
+
+            console.log(new Set([1, 2, {foo: 123}]));
+            console.log(
+                new Map([
+                    [{foo: 123}, [1, 2]],
+                    [{foo: 123}, [1, 2]],
+                ])
+            );
+
+            console.log(() => null);
+            console.log(function foo() {});
+            console.log(class Foo {});
+        }
+        foo();
+    });
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Test console forwarding',
+    resources: [],
+    skip: () => true,
+    run,
+};

--- a/tests/selftest_console.js
+++ b/tests/selftest_console.js
@@ -53,6 +53,14 @@ async function run(config) {
 
             console.trace();
             console.trace('bar');
+
+            const map = new Map();
+            map.set('map', map);
+            console.log(map);
+
+            const set = new Set();
+            set.add(set);
+            console.log(set);
         }
         foo();
     });

--- a/tests/selftest_console.js
+++ b/tests/selftest_console.js
@@ -48,6 +48,9 @@ async function run(config) {
             console.log(function foo() {});
             console.log(class Foo {});
 
+            console.log('foo');
+            console.log([1,2]);
+
             console.trace();
             console.trace('bar');
         }

--- a/tests/selftest_console.js
+++ b/tests/selftest_console.js
@@ -65,6 +65,9 @@ async function run(config) {
         foo();
     });
 
+    await page.goto('https://example.com');
+    await page.evaluate(() => console.log('Log from Example'));
+
     await closePage(page);
 }
 


### PR DESCRIPTION
This PR adds support for optionally forwarding browser console message to stdio/stderr. Values are automatically pretty printed as if they're logged from the node process itself. This is a huge advantaged compared to `karma` or other browser testing solutions. It makes debugging tree-like structures a lot easier (we have lots of those in Preact :stuck_out_tongue: ).

Due to limitations in puppeteer and the devtools protocol we need our own serialization format (essentially JSON) and pass it around as a string.

Supported data types:

- Primitives (string, number, boolean, null, undefined)
- Arrays + Objects
- Error objects
- Functions, Arrow Functions and classes
- Circular Data
- Map + Set

Screenshot:

![Screenshot from 2020-06-21 13-55-46](https://user-images.githubusercontent.com/1062408/85223939-f4ca0c00-b3c6-11ea-80c6-631e4bf55a53.png)
