### PR TITLE
+ navigation_context_destroyed testcase for #127

### DIFF
--- a/tests/selftest_navigation_context_destroyed.js
+++ b/tests/selftest_navigation_context_destroyed.js
@@ -1,0 +1,20 @@
+const {clickXPath, closePage, newPage} = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+
+    await page.setContent(`<html><script>
+        setTimeout(() => location.href = 'https://google.com/', 1000);
+    </script>
+    <body>original</body></html>`);
+    await clickXPath(page, '//button');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'Test clickXPath while navigating',
+    resources: [],
+    run,
+    expectedToFail: 'https://github.com/boxine/pentf/issues/127',
+};


### PR DESCRIPTION
When `clickXPath` is evaluated while a navigation context change happens, it fails as reported in #127 .

Reproduce the problematic behavior with a test.
