### PR TITLE
Change default concurrency to vary based on CPU count

### DIFF
--- a/tests/selftest_concurrency.js
+++ b/tests/selftest_concurrency.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+
+const {assertGreaterEqual} = require('../assert_utils');
+const {_computeConcurrency: computeConcurrency} = require('../config');
+
+async function run() {
+    assertGreaterEqual(computeConcurrency('cpus'), 1);
+
+    assert.equal(computeConcurrency('5', {cpuCount: 1}), 5);
+    assert.equal(computeConcurrency('cpus', {cpuCount: 12}), 12);
+    assert.equal(computeConcurrency('3+cpus', {cpuCount: 2}), 5);
+    assert.equal(computeConcurrency('3+cpus', {cpuCount: 3}), 6);
+    assert.equal(computeConcurrency('3 + 2 * cpus', {cpuCount: 1}), 5);
+    assert.equal(computeConcurrency('3 + 2 * cpus', {cpuCount: 2}), 7);
+
+    assert.throws(
+        () => computeConcurrency('invalid'),
+        {message: 'Invalid concurrency spec "invalid"'});
+}
+
+module.exports = {
+    description: 'Set concurrency based on CPU count',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Allow setting concurrency by number of CPUs

The concurrency setting must unify to competing interests:
The lower it is, the more stable tests tend to be. The higher it is, the faster tests run.
Optimal would be to use 100% CPU all the time, with no thread ever waiting.

In practice, we must make a trade-off, because we don't know how CPU-intensive the loads are.

Do so automatically by defaulting to 4 + Number of CPUs. For a small CI system with one or two CPUs, this will reduce the load in half.
For very beefy systems, it will make them use more CPUs.
For most current desktop/laptop users, the concurrency remains about the same.

In practice, on many CI-style systems we see more CPUs than we can actually use, so we may need to add a further limit instead of just `cpus`.
[I asked in the GitLab forum](https://forum.gitlab.com/t/optimal-concurrency-count-for-runner-jobs/39172) on how to do that.

