### PR TITLE
Change summary layout

### DIFF
--- a/results.js
+++ b/results.js
@@ -3,14 +3,12 @@ const assert = require('assert').strict;
 const utils = require('./utils');
 
 /**
-* Summarize test results.
-* @hidden
-* @param {*} config The pentf configuration object.
-* @param {Array<Object>} tasks All finished tasks.
-* @param {boolean} onTests Summarize tests instead of tasks.
-* @returns {string} A string with counts of the results.
-**/
-function resultCountString(config, tasks, onTests=false) {
+ * Get tests result summary data
+ * @param {*} config 
+ * @param {object[]} tasks 
+ * @param {boolean} onTests 
+ */
+function getResults(config, tasks, onTests=false) {
     const expectNothing = config.expect_nothing;
     assert(Array.isArray(tasks));
 
@@ -24,6 +22,37 @@ function resultCountString(config, tasks, onTests=false) {
         tasks, t => t.expectedToFail && t.status === 'error');
     const expectedToFailButPassed = !expectNothing && utils.count(
         tasks, t => t.expectedToFail && t.status === 'success');
+    
+    const itemName = (onTests || ((config.repeat || 1) === 1)) ? 'tests' : 'tasks';
+
+    return {
+        success,
+        errored,
+        flaky,
+        skipped,
+        expectedToFail,
+        expectedToFailButPassed,
+        itemName,
+    };
+}
+
+/**
+* Summarize test results for PDF.
+* @hidden
+* @param {*} config The pentf configuration object.
+* @param {Array<Object>} tasks All finished tasks.
+* @param {boolean} onTests Summarize tests instead of tasks.
+* @returns {string} A string with counts of the results.
+**/
+function resultCountString(config, tasks, onTests=false) {
+    const {
+        success,
+        errored,
+        flaky,
+        skipped,
+        expectedToFail,
+        expectedToFailButPassed
+    } = getResults(config, tasks, onTests);
 
     const itemName = (onTests || ((config.repeat || 1) === 1)) ? 'tests' : 'tasks';
     let res = `${success} ${itemName} passed, ${errored} failed`;
@@ -43,5 +72,6 @@ function resultCountString(config, tasks, onTests=false) {
 }
 
 module.exports = {
-    resultCountString,
+    getResults,
+    resultCountString
 };


### PR DESCRIPTION
This is an attempt to make the summary output easier to read. It's a bit longer than the current output though. Let me know what you think :+1: 

Before:

![Screenshot from 2020-07-04 12-11-21](https://user-images.githubusercontent.com/1062408/86510398-8d14b780-bdef-11ea-99b1-b8d065b33aa1.png)


After:

![Screenshot from 2020-07-04 12-10-55](https://user-images.githubusercontent.com/1062408/86510395-88500380-bdef-11ea-9492-414886f90a9d.png)
