### PR TITLE
Update error cli output

### DIFF
--- a/output.js
+++ b/output.js
@@ -401,7 +401,7 @@ async function formatError(config, err) {
         .map(frame => {
             if (!config.no_clear_line && frame.name) {
                 // Only show frame for errors in the user's code
-                if (!nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(process.cwd())) {
+                if (!nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(config._rootDir)) {
                     nearestFrame = frame;
                 }
 

--- a/output.js
+++ b/output.js
@@ -87,7 +87,10 @@ function resultSummary(config, tasks, onTests=false) {
     );
     const pad = str => (' '.repeat(maxChars) + str).slice(-maxChars);
 
-    let res = color(config, 'green', `  ${pad(success)} ${itemName} passed\n`);
+    let res = '';
+    if (success > 0) {
+        res += color(config, 'green', `  ${pad(success)} ${itemName} passed\n`);
+    }
     if (errored > 0) {
         res += color(config, 'red', `  ${pad(errored)} failed\n`);
     }

--- a/output.js
+++ b/output.js
@@ -357,7 +357,7 @@ function genCodeFrame(config, content, lineNum, columnNum, before, after) {
     return lines.slice(startLine, endLine)
         .map((line, i) => {
             const n = startLine + i;
-            const currentLine = (padding + n).slice(-maxChars);
+            const currentLine = (padding + (n + 1)).slice(-maxChars);
 
             const normalized = tabs2Spaces(line);
             if (n === lineNum) {

--- a/output.js
+++ b/output.js
@@ -423,7 +423,9 @@ async function formatError(config, err) {
         log(config, 'INTERNAL WARNING: Failed to read stack frame code: ' + readError);
     }
 
-    const message = `${err.name}: ${err.message}`;
+    let message = `${err.name}: ${err.message}`;
+    if (!message.endsWith('\n')) message +='\n';
+
     return '\n'
         + diff
         + indentLines(message, 1)

--- a/output.js
+++ b/output.js
@@ -396,7 +396,7 @@ async function formatError(config, err) {
         .map(frame => {
             if (!config.no_clear_line && frame.name) {
                 // Only show frame for errors in the user's code
-                if (!nearestFrame && !/node_modules/.test(frame.fileName)) {
+                if (!nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(process.cwd())) {
                     nearestFrame = frame;
                 }
 

--- a/output.js
+++ b/output.js
@@ -88,7 +88,9 @@ function resultSummary(config, tasks, onTests=false) {
     const pad = str => (' '.repeat(maxChars) + str).slice(-maxChars);
 
     let res = color(config, 'green', `  ${pad(success)} ${itemName} passed\n`);
-    res += color(config, 'red', `  ${pad(errored)} failed\n`);
+    if (errored > 0) {
+        res += color(config, 'red', `  ${pad(errored)} failed\n`);
+    }
     if (flaky) {
         res += `  ${pad(flaky)} flaky\n`;
     }


### PR DESCRIPTION
This PR makes some minor changes to the console runner output.
 
- Fix missing newline after error message e9f39bf
- Only show code frame for user code 5f3c316 
- Only show failed summary if there are failed tests 26ef3b1
- Only show success summary when tests succeeded c78d1b8
-  Fix code frame line numbers being off by 1 92d7df5