### PR TITLE
runner: Verbose log status on end

### DIFF
--- a/main.js
+++ b/main.js
@@ -7,7 +7,7 @@ const {readConfig, parseArgs} = require('./config');
 const {readFile} = require('./utils');
 const runner = require('./runner');
 const render = require('./render');
-const {color} = require('./output');
+const {color, logVerbose} = require('./output');
 const {testsVersion, pentfVersion} = require('./version');
 const {loadTests} = require('./loader');
 
@@ -96,6 +96,7 @@ async function real_main(options={}) {
     if (!config.keep_open) {
         const anyErrors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
         const retCode = (!anyErrors || config.exit_zero) ? 0 : 3;
+        logVerbose(`Terminating with exit code ${retCode}`);
         process.exit(retCode);
     }
 }

--- a/render.js
+++ b/render.js
@@ -6,6 +6,7 @@ const {html2pdf} = require('./browser_utils');
 const {timezoneOffsetString} = require('./utils');
 const {resultCountString} = require('./results');
 
+const output = require('./output');
 const utils = require('./utils');
 
 function craftResults(config, test_info) {
@@ -64,21 +65,25 @@ function craftResults(config, test_info) {
 
 async function doRender(config, results) {
     if (config.json) {
+        output.logVerbose('Rendering to JSON ...');
         const json = JSON.stringify(results, undefined, 2) + '\n';
         await promisify(fs.writeFile)(config.json_file, json, {encoding: 'utf-8'});
     }
 
     if (config.markdown) {
+        output.logVerbose('Rendering to Markdown ...');
         const md = markdown(results);
         await promisify(fs.writeFile)(config.markdown_file, md, {encoding: 'utf-8'});
     }
 
     if (config.html) {
+        output.logVerbose('Rendering to HTML ...');
         const html_code = html(results);
         await promisify(fs.writeFile)(config.html_file, html_code, {encoding: 'utf-8'});
     }
 
     if (config.pdf) {
+        output.logVerbose('Rendering to PDF ...');
         await pdf(config, config.pdf_file, results);
     }
 }


### PR DESCRIPTION
In our CI, we're seeing pentf runs hang after finishing all tests.
Log more information if `-v` is given.
