### PR TITLE
lockserver: Allow a client length of up to 256 chars

### DIFF
--- a/lockserver/lockserver.js
+++ b/lockserver/lockserver.js
@@ -61,7 +61,7 @@ async function acquireLocks(locks, request, response) {
     if (!data.client) {
         return requestError(response, 'client is empty');
     }
-    if (data.client.length > 100) {
+    if (data.client.length > 256) {
         return requestError(response, 'client is too long');
     }
     if (! Array.isArray(data.resources)) {
@@ -128,7 +128,7 @@ async function releaseLocks(locks, request, response) {
     if (!data.client) {
         return requestError(response, 'client is empty');
     }
-    if (data.client.length > 100) {
+    if (data.client.length > 256) {
         return requestError(response, 'client is too long');
     }
     if (! Array.isArray(data.resources)) {


### PR DESCRIPTION
We want to allow longer and thus more descriptive client names, including pentf version, branch names, etc.
This is already implemented in our proprietary lockserver.
