### PR TITLE
external_locking: Improve & fix client name under CI

### DIFF
--- a/tests/selftest_ci_client_name.js
+++ b/tests/selftest_ci_client_name.js
@@ -14,7 +14,7 @@ async function run() {
         },
         nowStr: '2020-07-25T12:44:51.305+02:00',
     }),
-        'ci a-project-with-an-extremely-un de2b4c3 dev' +
+    'ci a-project-with-an-extremely-un de2b4c3 dev' +
         ` https://gitlab.example.org/group/project/-/jobs/1234567 ${pentfVersion()}` +
         ' 2020-07-25T12:44:51.305+02:00'
     );

--- a/tests/selftest_ci_client_name.js
+++ b/tests/selftest_ci_client_name.js
@@ -1,0 +1,30 @@
+const assert = require('assert');
+const { _generateClientName: generateClientName } = require('../external_locking');
+const { pentfVersion } = require('../version');
+
+async function run() {
+    assert.equal(generateClientName({
+        env: {
+            CI_PROJECT_NAME: 'a-project-with-an-extremely-unreasonably-elaborate-long-name',
+            CI_BRANCH_NAME: 'a-branch-with-an-extremely-unreasonably-elaborate-long-name',
+            CI_COMMIT_SHA: 'de2b4c34ef86570c601d196a78270b71347752f7',
+            CI_COMMIT_SHORT_SHA: 'de2b4c3',
+            CI_ENVIRONMENT_NAME: 'dev\n',
+            CI_JOB_URL: 'https://gitlab.example.org/group/project/-/jobs/1234567',
+        },
+        nowStr: '2020-07-25T12:44:51.305+02:00',
+    }),
+        'ci a-project-with-an-extremely-un de2b4c3 dev' +
+        ` https://gitlab.example.org/group/project/-/jobs/1234567 ${pentfVersion()}` +
+        ' 2020-07-25T12:44:51.305+02:00'
+    );
+}
+
+module.exports = {
+    run,
+    description: (
+        'External locking uses a client ID to be able to determine which job is holding a lock.' +
+        'Check the generation of this ID on a CI server.'
+    ),
+    resources: [],
+};


### PR DESCRIPTION
The new limit for clients is 256, allowing us to stuff a bit more in there:
- Fix general display (prefixDash previously _appended_ a dash)
- Apply limits to all CI variables
- Make sure to properly trim spaces and newlines (wtf?) in CI environment variables
- Include a URL to the CI job if available!
- Include pentf version to spot out-of-date jobs (or exclude older pentf versions from error analysis)
