### PR TITLE
runner: Set job URL in sentry reports

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -116,6 +116,9 @@ async function run_task(config, task) {
                     Sentry.withScope(scope => {
                         scope.setTag('task', task.name);
                         scope.setTag('testcase', task.tc.name);
+                        if (process.env.CI_JOB_URL) {
+                            scope.setTag('jobUrl', process.env.CI_JOB_URL);
+                        }
                         Sentry.captureException(e);
                     });
                 }


### PR DESCRIPTION
This makes it easy to see which project is affected, and one can jump to the pipeline directly.
