### PR TITLE
Remove config reference from runner state

### DIFF
--- a/external_locking.js
+++ b/external_locking.js
@@ -198,20 +198,22 @@ async function refresh(state) {
 }
 
 /**
+ * @param {import('./config').Config} state 
  * @param {import('./runner').RunnerState} state 
  * @private
  */
-async function init(state) {
-    if (state.config.no_external_locking) return;
+async function init(config, state) {
+    if (config.no_external_locking) return;
     state.external_locking_refresh_timeout = setTimeout(() => refresh(state), REFRESH_INTERVAL);
 }
 
 /**
+ * @param {import('./config').Config} config 
  * @param {import('./runner').RunnerState} state 
  * @private
  */
-async function shutdown(state) {
-    if (state.config.no_external_locking) return;
+async function shutdown(config, state) {
+    if (config.no_external_locking) return;
     assert(state.external_locking_refresh_timeout);
     clearTimeout(state.external_locking_refresh_timeout);
 }

--- a/locking.js
+++ b/locking.js
@@ -26,14 +26,15 @@ function annotateTaskResources(config, task) {
 }
 
 /**
+ * @param {import('./config').Config} config 
  * @param {import('./runner').RunnerState} state 
  * @private
  */
-async function init(state) {
+async function init(config, state) {
+    assert(config);
     assert(state);
-    assert(state.config);
     state.locks = new Set();
-    external_locking.init(state);
+    external_locking.init(config, state);
 }
 
 /**
@@ -42,7 +43,7 @@ async function init(state) {
  * @private
  */
 async function shutdown(config, state) {
-    external_locking.shutdown(state);
+    external_locking.shutdown(config, state);
     state.locks.length = 0;
     assert.equal(
         state.locks.size, 0,

--- a/runner.js
+++ b/runner.js
@@ -366,9 +366,9 @@ async function testCases2tasks(config, testCases) {
 
 /**
  * @typedef {Object} RunnerState
- * @property {import('./config').Config} config
  * @property {Task[]} tasks
- * @property {Set<string>} locks
+ * @property {Set<string>} [locks]
+ * @property {NodeJS.Timeout} [external_locking_refresh_timeout]
  */
 
 /**
@@ -385,7 +385,6 @@ async function run(config, testCases) {
     const tasks = await testCases2tasks(config, testCases);
     /** @type {RunnerState} */
     const state = {
-        config,
         tasks,
     };
 
@@ -440,7 +439,7 @@ async function run(config, testCases) {
             return;
         }
 
-        await locking.init(state);
+        await locking.init(config, state);
 
         if (config.concurrency === 0) {
             await sequential_run(config, state);


### PR DESCRIPTION
This PR makes the separation between `config` and `state` more clear by keeping them separate.