### PR TITLE
version: Fall back to CI environment variables

### DIFF
--- a/version.js
+++ b/version.js
@@ -25,8 +25,17 @@ async function testsVersion(config) {
 
         return tagsRepr + gitVersion + suffix;
     } catch(e) {
-        return 'unknown';
+        // go on
     }
+
+    // Are we in a CI pipeline? Use these values instead
+    const {env} = process;
+    if (env.CI_COMMIT_SHORT_SHA) {
+        const name = (env.CI_COMMIT_TAG || env.CI_COMMIT_BRANCH || '').trim();
+        return (name ? name + ' ' : '') + env.CI_COMMIT_SHORT_SHA.trim();
+    }
+
+    return 'unknown';
 }
 
 function pentfVersion() {


### PR DESCRIPTION
Version determination (e.g. in PDFs) works by looking at the git state. However, in docker images, there often is no `.git` directory.

Instead, look at the environment variables during building. The docker image can then be built as:
```
docker build \
  --build-arg "CI_COMMIT_SHORT_SHA=$CI_COMMIT_SHORT_SHA" \
  --build-arg "CI_COMMIT_TAG=$CI_COMMIT_TAG" \
  --buil-arg "CI_COMMIT_BRANCH=$CI_COMMIT_BRANCH" \
  --tag $CI_REGISTRY_IMAGE:latest .
```
