### PR TITLE
Fix unable to overwrite language multiple times

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -688,11 +688,15 @@ async function setLanguage(page, lang) {
     await page.setExtraHTTPHeaders({'Accept-Language': lang.join(',')}); // For HTTP requests
     await page.evaluateOnNewDocument(lang => { // For JavaScript code
         Object.defineProperty(navigator, 'language', {
+            // Allow future setLanguage() calls to overwrite this property
+            configurable: true,
             get: function() {
                 return lang[0];
             }
         });
         Object.defineProperty(navigator, 'languages', {
+            // Allow future setLanguage() calls to overwrite this property
+            configurable: true,
             get: function() {
                 return lang;
             }

--- a/tests/selftest_language.js
+++ b/tests/selftest_language.js
@@ -1,0 +1,36 @@
+const assert = require('assert').strict;
+const http = require('http');
+const {newPage, closePage, setLanguage} = require('../browser_utils');
+
+async function run(config) {
+    const server = http.createServer((req, res) => {
+        res.end('Hello World!');
+    });
+    const port = await new Promise((resolve, reject) => {
+        server.listen(0, (err) => {
+            if (err) return reject(err);
+
+            const {port} = server.address();
+            return resolve(port);
+        });
+    });
+    const page = await newPage(config);
+    await page.goto(`http://localhost:${port}/`);
+
+    await setLanguage(page, 'de-DE');
+    await page.reload();
+    let lang = await page.evaluate(() => window.navigator.language);
+    assert.equal(lang, 'de-DE');
+
+    await setLanguage(page, 'en-US');
+    await page.reload();
+    lang = await page.evaluate(() => window.navigator.language);
+    assert.equal(lang, 'en-US');
+
+    await closePage(page);
+}
+
+module.exports = {
+    run,
+    description: 'Set browser language',
+};


### PR DESCRIPTION
Fixes the following error when `setLanguage()` is called multiple times in a test:

```
Uncaught TypeError: Cannot redefine property: language
    at Function.defineProperty (<anonymous>)
    at <anonymous>:2:16
    at <anonymous>:16:7
```