### PR TITLE
Add --debug preset flag

### DIFF
--- a/config.js
+++ b/config.js
@@ -54,7 +54,7 @@ function computeConcurrency(spec, {cpuCount=undefined}={}) {
     ).reduce((x, y) => x + y, 0);
 }
 
-function parseArgs(options) {
+function parseArgs(options, raw_args) {
     const DEFAULT_HTML_NAME = 'results.html';
     const DEFAULT_JSON_NAME = 'results.json';
     const DEFAULT_MARKDOWN_NAME = 'results.md';
@@ -261,6 +261,10 @@ function parseArgs(options) {
         help: 'Forward browser console logs',
         action: 'storeTrue',
     });
+    puppeteer_group.addArgument(['-d', '--debug'], {
+        help: 'Shorthand for "--keep-open --devtools-preserve --forward-console"',
+        action: 'storeTrue',
+    });
 
     const runner_group = parser.addArgumentGroup({title: 'Test runner'});
     runner_group.addArgument(['-C', '--concurrency'], {
@@ -352,7 +356,7 @@ function parseArgs(options) {
         help: 'Display the locking client ID we would use if we would lock something now',
     });
 
-    const args = parser.parseArgs();
+    const args = parser.parseArgs(raw_args);
     if (args.json_file !== DEFAULT_JSON_NAME && !args.json) {
         console.log('Warning: --json-file given, but not -j/--json. Will NOT write JSON.'); // eslint-disable-line no-console
     }
@@ -366,6 +370,11 @@ function parseArgs(options) {
         console.log('Warning: --pdf-file given, but not --pdf. Will NOT write PDF.'); // eslint-disable-line no-console
     }
 
+    if (args.debug) {
+        args.devtools_preserve = true;
+        args.keep_open = true;
+        args.forward_console = true;
+    }
     if (args.keep_open) {
         args.headless = false;
     }

--- a/main.js
+++ b/main.js
@@ -40,7 +40,7 @@ async function real_main(options={}) {
     }
 
 
-    const args = parseArgs(options);
+    const args = parseArgs(options, process.argv.slice(2));
     const config = await readConfig(options, args);
     if (options.defaultConfig) {
         options.defaultConfig(config);

--- a/tests/selftest_args_debug.js
+++ b/tests/selftest_args_debug.js
@@ -1,0 +1,24 @@
+const assert = require('assert').strict;
+const {parseArgs} = require('../config');
+
+async function run() {
+    const args = parseArgs(
+        {
+            rootDir: __dirname,
+            description: 'foobar',
+        },
+        ['--debug']
+    );
+    assert.equal(args.debug, true);
+    assert.equal(args.devtools, true);
+    assert.equal(args.devtools_preserve, true);
+    assert.equal(args.forward_console, true);
+    assert.equal(args.keep_open, true);
+    assert.equal(args.headless, false);
+}
+
+module.exports = {
+    description: 'pentf --debug flag',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
I've asked around how devs debug single tests and practically everyone is using `-k --devtools`. They were not aware of `--forward-console`. Seeing that the combination is that common, it leads me to believe that there is value to unify them behind a single flag for debugging single test cases.