### PR TITLE
Close browser window on successful test

### DIFF
--- a/main.js
+++ b/main.js
@@ -102,8 +102,10 @@ async function real_main(options={}) {
     }
 
     await render.doRender(config, results);
-    if (!config.keep_open) {
-        const anyErrors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
+    
+    const anyErrors = results.tests.some(s => s.status === 'error' && (!s.expectedToFail || config.expect_nothing));
+    // Only exit if there are no errors or the user has passed `--keep_open`
+    if (!config.keep_open || !anyErrors) {
         const retCode = (!anyErrors || config.exit_zero) ? 0 : 3;
         logVerbose(`Terminating with exit code ${retCode}`);
         process.exit(retCode);

--- a/runner.js
+++ b/runner.js
@@ -107,8 +107,8 @@ async function run_task(config, task) {
                     `INTERNAL ERROR: failed to take screenshot of #${task.id} (${task.name}): ${e}`);
             }
         }
-        // Close all browser windows
-        if (! config.keep_open && task_config._browser_pages.length > 0) {
+        // Close all browser windows, except when keep_open is set and we have a failure.
+        if ((task.expectedToFail && !config.expect_nothing || ! config.keep_open) && task_config._browser_pages.length > 0) {
             if (config.verbose) {
                 output.log(
                     config,


### PR DESCRIPTION
Close browser windows if the test was successful and only close them when we encountered a failure. Otherwise the cli will never exit with `--keep-open`.