### PR TITLE
Extend release script

### DIFF
--- a/release
+++ b/release
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -ex
+set -e
 
 CURRENT_VERSION=$(node -e 'console.log(require("./package.json").version)')
 echo "Enter new version number (current: $CURRENT_VERSION):"
@@ -8,6 +8,18 @@ read VERSION
 # "npm version <VERSION>" updates the version number in package.json
 # and package-lock.json, creates a git commit and the tag in one command
 npm version $VERSION -m "release v%s"
+
+./update-readme.js
+git diff
+
+echo -n Releasing in
+for i in $(seq 5); do
+	echo -n " $(expr 6 - $i)"
+	sleep 1
+done
+echo
+
+set -x
 git push
 git push --tags
 npm publish


### PR DESCRIPTION
- Automatically call `./update-readme.js` to avoid the busywork of calling it manually.
- Add a 5s timeout before releasing.
- Only activate `-e` when the commads get interesting.
