### PR TITLE
Order results by severity in generated artifacts

### DIFF
--- a/config.js
+++ b/config.js
@@ -418,7 +418,7 @@ async function readConfigFile(configDir, env) {
 }
 
 /**
- * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string}} Config
+ * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean}} Config
  */
 
 /**

--- a/tests/selftest_result_order.js
+++ b/tests/selftest_result_order.js
@@ -1,0 +1,37 @@
+const assert = require('assert').strict;
+const {craftResults} = require('../render');
+const runner = require('../runner');
+
+async function run(config) {
+    const noop = async () => null;
+    const fail = async () => {
+        throw new Error('fail');
+    };
+
+    /** @type {import('../runner').TestCase[]} */
+    const cases = [
+        {name: 'success', run: noop},
+        {name: 'skipped', run: noop, skip: () => true},
+        {name: 'expectedToFailButPassed', run: noop, expectedToFail: 'fail'},
+        {name: 'expectedToFail', run: fail, expectedToFail: 'fail'},
+        {name: 'error #2', run: fail},
+        {name: 'error #1', run: fail},
+    ];
+
+    const testConfig = {...config, logFunc: () => null};
+    const info = await runner.run(testConfig, cases);
+    const results = craftResults(config, info).tests.map(t => t.name);
+    assert.deepEqual(results, [
+        'error #1',
+        'error #2',
+        'expectedToFailButPassed',
+        'expectedToFail',
+        'skipped',
+        'success',
+    ]);
+}
+
+module.exports = {
+    run,
+    description: 'Order test results by severity in rendered artifacts',
+};


### PR DESCRIPTION
This PR orders results in generated artifacts by severity, meaning failures are listed first. This affects only the artifacts themselves, not the status output in the cli which is very different.