### PR TITLE
Add support for effectful teardown functions

### DIFF
--- a/tests/selftest_teardown.js
+++ b/tests/selftest_teardown.js
@@ -1,0 +1,55 @@
+const assert = require('assert').strict;
+const runner = require('../runner');
+
+/**
+ * @param {import('../runner').TaskConfig} config
+ * @param {string[]} output
+ */
+function effect(config, output) {
+    output.push('run effect');
+    runner.onTeardown(config, () => {
+        output.push('teardown effect');
+    });
+}
+
+/**
+ * @param {import('../runner').TaskConfig} config
+ * @param {string[]} output
+ */
+function failingEffect(config, output) {
+    output.push('run failingEffect');
+    runner.onTeardown(config, async () => {
+        throw new Error('fail');
+    });
+}
+
+async function run(config) {
+    const output = [];
+    await runner.run(
+        {...config, logFunc: () => null},
+        [
+            { name: 'normal teardown', run: async (config) => {
+                effect(config, output);
+            }}
+        ]
+    );
+    assert.deepEqual(output, ['run effect', 'teardown effect']);
+
+    // Fail on teardown
+    const logs = [];
+    await runner.run(
+        {...config, logFunc: (_, msg) => logs.push(msg)},
+        [
+            { name: 'normal teardown', run: async (config) => {
+                failingEffect(config, output);
+            }}
+        ]
+    );
+
+    assert(/INTERNAL ERROR.*teardown/.test(logs.join('')), 'should print internal error message');
+}
+
+module.exports = {
+    run,
+    description: 'Call teardown functions'
+};


### PR DESCRIPTION
This PR adds support for effectful teardown functions that can be used for cleanup code. A use case for that is deleting a user in a database, releasing resources etc. It's generic enough that it can be used for anything. Teardown hooks will be invoked after a task is completed, regardless of the failure state.

```js
async function createUser(config) {
  const user = await apiFetchUser();
  onTeardown(config, () => apiRemoveUser(user));
}

async function run(config) {
  const user = await createUser(config);
  // ...do some test assertions with the user

  // User will be deleted automatically at the end of the test
}
```

Fixes #121 .