### PR TITLE
Strip ansi color codes from Sentry breadcrumbs

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -5,6 +5,7 @@ const path = require('path');
 const {performance} = require('perf_hooks');
 const {promisify} = require('util');
 const mkdirp = require('mkdirp');
+const kolorist = require('kolorist');
 
 const browser_utils = require('./browser_utils');
 const email = require('./email');
@@ -493,6 +494,13 @@ async function run(config, testCases) {
         Sentry.init({
             dsn: sentry_dsn,
             environment: config.env,
+            beforeBreadcrumb(breadcrumb) {
+                // Strip ansi color codes from sentry messages.
+                if (breadcrumb.message && typeof breadcrumb.message === 'string') {
+                    breadcrumb.message = kolorist.stripColors(breadcrumb.message);
+                }
+                return breadcrumb;
+            },
             integrations: [],
         });
     }


### PR DESCRIPTION
Before:

```bash
[7m[34m STATUS [39m[27m at 2020-07-29T09:27:38.647Z: [33m82/83 done[39m, 1 running
  my-test [31m10min 5s[39m
```

After:

```bash
 STATUS  at 2020-07-29T09:27:38.647Z: 82/83 done, 1 running
  my-test 10min 5s
```


