### PR TITLE
Fix missing code frame on unset env variable

### DIFF
--- a/output.js
+++ b/output.js
@@ -489,7 +489,7 @@ async function formatError(config, err) {
         .map(frame => {
             if (frame.name) {
                 // Only show frame for errors in the user's code
-                if (process.env.PENTF_SHOW_CODE_FRAMES === 'false' && !nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(config._rootDir)) {
+                if (process.env.PENTF_SHOW_CODE_FRAMES !== 'false' && !nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(config._rootDir)) {
                     nearestFrame = frame;
                 }
 


### PR DESCRIPTION
Not sure what happened, but the logic was backwards with `PENTF_SHOW_CODE_FRAMES`. This PR corrects that.