### PR TITLE
Fix error on tryping to read default timeout

### DIFF
--- a/browser_console.js
+++ b/browser_console.js
@@ -127,9 +127,10 @@ async function forwardBrowserConsole(page) {
         };
     }, serialize.toString());
 
+    const browser = page.browser();
     page.on('console', async message => {
         let resolve;
-        page._logs.push(new Promise(r => resolve = r));
+        browser._logs.push(new Promise(r => resolve = r));
 
         let type = message.type();
         // Correct log type for warning messages

--- a/tests/selftest_newtab.js
+++ b/tests/selftest_newtab.js
@@ -1,0 +1,14 @@
+const { newPage, closePage, waitForVisible } = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await (await page.browser()).newPage();
+    await page.goto('https://example.com');
+    await waitForVisible(page, 'h1');
+    await closePage(page);
+}
+
+module.exports = {
+    run,
+    description: 'Open new tabs without crashing',
+};


### PR DESCRIPTION
This PR fixes the following error:

```bash
Cannot read property 'default_timeout' of undefined
```

Problem is that when a frame or a page is created via standard functions from `puppeteer`, they won't have our internal properties. Therefore we need to lift them up to the nearest common ancestor. The nearest one is the `Browser` instance and with that both frames and pages work.