### PR TITLE
Write logs to disk via --log-file

### DIFF
--- a/config.js
+++ b/config.js
@@ -85,6 +85,12 @@ function parseArgs(options, raw_args) {
         action: 'storeTrue',
         help: 'Let tests output diagnostic details',
     });
+    output_group.addArgument(['--log-file'], {
+        help: 'Write verbose log information to disk. Doesn\'t affect tty logging.',
+        metavar: 'FILE',
+        type: 'string',
+        dest: 'log_file'
+    });
     output_group.addArgument(['-q', '--quiet'], {
         action: 'storeTrue',
         help: 'Do not output test status',
@@ -424,7 +430,7 @@ async function readConfigFile(configDir, env) {
 }
 
 /**
- * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean}} Config
+ * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream}} Config
  */
 
 /**

--- a/main.js
+++ b/main.js
@@ -4,7 +4,7 @@ const fs = require('fs');
 const path = require('path');
 
 const {readConfig, parseArgs} = require('./config');
-const {readFile} = require('./utils');
+const {readFile, localIso8601} = require('./utils');
 const runner = require('./runner');
 const render = require('./render');
 const {color, logVerbose} = require('./output');
@@ -94,6 +94,13 @@ async function real_main(options={}) {
         const json_input = await readFile(args.load_json, {encoding: 'utf-8'});
         results = JSON.parse(json_input);
     } else {
+        if (config.log_file && !config.log_file_stream) {
+            const stream = fs.createWriteStream(config.log_file, { flags: 'w' });
+            const time = localIso8601();
+            stream.write(`${time} Start runner\n`);
+            config.log_file_stream = stream;
+        }
+
         // Run tests
         const test_info = await runner.run(config, test_cases);
         if (!test_info) return;

--- a/tests/log_file_tests/foo.js
+++ b/tests/log_file_tests/foo.js
@@ -1,0 +1,11 @@
+const assert = require('assert').strict;
+
+async function run() {
+    assert.equal(1, 1);
+}
+
+module.exports = {
+    description: 'Test browser_utils.getAttribute',
+    resources: ['A', 'B'],
+    run,
+};

--- a/tests/log_file_tests/run
+++ b/tests/log_file_tests/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const pentf = require('../../index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});

--- a/tests/selftest_log_file.js
+++ b/tests/selftest_log_file.js
@@ -1,0 +1,44 @@
+const assert = require('assert').strict;
+const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
+
+async function run() {
+    const logFile = path.join(__dirname, 'log_file_tests', 'output.log');
+    const sub_run = path.join(__dirname, 'log_file_tests', 'run');
+
+    const remove = async () => {
+        try {
+            await fs.promises.unlink(logFile);
+        } catch (err) {
+            // Ignore any errors
+        }
+    };
+
+    // Delete log file if it exists
+    remove();
+
+    await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '--log-file', logFile],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    const content = await fs.promises.readFile(logFile, 'utf8');
+
+    assert(/\[locking\]/.test(content), 'has verbose locking information');
+    assert(/\[runner\]/.test(content), 'has runner information');
+    assert(/\[task\]/.test(content), 'has task information');
+
+    remove();
+}
+
+module.exports = {
+    run,
+    description: 'Writes logs to disk'
+};


### PR DESCRIPTION
This PR adds a new command line flag `--log file FILE` to persist log messages to disk. It will always print all messages, regardless if `--verbose` or `--locking-verbose` was set or not.