### PR TITLE
Show fallback value if console message cannot be serialized

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -149,7 +149,7 @@ async function newPage(config, chrome_args=[]) {
 
     browser._logs = [];
     if (config.forward_console) {
-        await forwardBrowserConsole(page);
+        await forwardBrowserConsole(config, page);
     }
 
     if (config._browser_pages) {

--- a/tests/console_navigation/console_test.js
+++ b/tests/console_navigation/console_test.js
@@ -1,0 +1,18 @@
+const { newPage } = require('../../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.goto('https://google.com');
+    await page.evaluate(() => {
+        setTimeout(() => {
+            console.warn('Some warning');
+            console.log({foo: 'bar'});
+        }, 0);
+        window.location = 'https://example.com';
+    });
+}
+
+module.exports = {
+    description: 'Print fallback console when execution context is destroyed.',
+    run,
+};

--- a/tests/console_navigation/run
+++ b/tests/console_navigation/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const pentf = require('../../index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});

--- a/tests/selftest_console_navigation.js
+++ b/tests/selftest_console_navigation.js
@@ -1,0 +1,26 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'console_navigation', 'run');
+    const {stdout} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '--forward-console'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/Some warning/.test(stdout), 'Should use fallback log');
+}
+
+module.exports = {
+    description: 'Print fallback console when execution context is destroyed.',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
During tests navigation may happen quickly and the execution context may already be destroyed before we attempt to serialize the messages. In this case we can just fall back to leverage the string based format from puppeteer.