### PR TITLE
Suite API

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,29 +111,29 @@ Have a look in the [API documentation](https://boxine.github.io/pentf/) for vari
 Pentf supports creating multiple test cases in the same file, which is commonly referred to as a suite.
 
 ```js
-function runSuite(it, describe) {
-    it('should do something', async () => {});
-    it('should do something else', async () => {});
+function suite(test, describe) {
+    test('should do something', async () => {});
+    test('should do something else', async () => {});
 
     describe('sub feature', () => {
-        it('should work too', async () => {});
+        test('should work too', async () => {});
     });
 }
 
 module.exports = {
-    runSuite
+    suite
 }
 ```
 
 Specific tests or groups can be focused by appending `.only`. Only those defined with that property will run when the current suite is executed.
 
 ```js
-function runSuite(it, describe) {
-    it('I won\'t run', async () => {});
-    it.only('I will run', async () => {});
+function suite(test, describe) {
+    test('I won\'t run', async () => {});
+    test.only('I will run', async () => {});
 
     describe.only('foo', () => {
-        it('I will run too', async() => {});
+        test('I will run too', async() => {});
     });
 }
 ```
@@ -141,12 +141,12 @@ function runSuite(it, describe) {
 Test cases or groups can be skipped in a similar way by appending `.skip`. Those tests will not be executed during a test run.
 
 ```js
-function runSuite(it, describe) {
-    it('I will run', async () => {});
-    it.skip('I won\'t run', async () => {});
+function suite(test, describe) {
+    test('I will run', async () => {});
+    test.skip('I won\'t run', async () => {});
 
     describe.skip('foo', () => {
-        it('I won\'t run', async() => {});
+        test('I won\'t run', async() => {});
     });
 }
 ```

--- a/README.md
+++ b/README.md
@@ -106,6 +106,51 @@ Note that while the above example tests a webpage with [puppeteer](https://githu
 
 Have a look in the [API documentation](https://boxine.github.io/pentf/) for various helper functions.
 
+### Creating a test suite
+
+Pentf supports creating multiple test cases in the same file, which is commonly referred to as a suite.
+
+```js
+function runSuite(it, describe) {
+    it('should do something', async () => {});
+    it('should do something else', async () => {});
+
+    describe('sub feature', () => {
+        it('should work too', async () => {});
+    });
+}
+
+module.exports = {
+    runSuite
+}
+```
+
+Specific tests or groups can be focused by appending `.only`. Only those defined with that property will run when the current suite is executed.
+
+```js
+function runSuite(it, describe) {
+    it('I won\'t run', async () => {});
+    it.only('I will run', async () => {});
+
+    describe.only('foo', () => {
+        it('I will run too', async() => {});
+    });
+}
+```
+
+Test cases or groups can be skipped in a similar way by appending `.skip`. Those tests will not be executed during a test run.
+
+```js
+function runSuite(it, describe) {
+    it('I will run', async () => {});
+    it.skip('I won\'t run', async () => {});
+
+    describe.skip('foo', () => {
+        it('I won\'t run', async() => {});
+    });
+}
+```
+
 ## Tips for writing good tests
 
 By their very nature, end-to-end tests can be flaky, i.e. sometimes succeed and sometimes fail when run multiple times. We want the tests to only relay the flakiness of the systems we test, and not introduce any additional flakiness ourselves. Here are a few tips for that:

--- a/src/loader.js
+++ b/src/loader.js
@@ -69,9 +69,10 @@ function loadSuite(suiteName, builder) {
     let i = 0;
 
     /**
+     * Create a test case
      * @param {string} description
      * @param {(config: import('./config').Config) => Promise<void>} run
-     * @param {{ skip: () => Promise<boolean> | boolean}} options
+     * @param {TestOptions} options
      */
     function test(description, run, options = {}) {
         const arr = onlyInScope ? only : tests;
@@ -83,6 +84,12 @@ function loadSuite(suiteName, builder) {
         });
     }
 
+    /**
+     * Only run this test case in the current file
+     * @param {string} description
+     * @param {(config: import('./config').Config) => Promise<void>} run
+     * @param {TestOptions} options
+     */
     test.only = (description, run, options = {}) => {
         only.push({
             description,
@@ -92,12 +99,22 @@ function loadSuite(suiteName, builder) {
         });
     };
 
+    /**
+     * Create a group for test cases
+     * @param {string} description
+     * @param {() => void} callback
+     */
     function suite(description, callback) {
         groups.push(description);
         callback();
         groups.pop();
     }
 
+    /**
+     * Only run the test cases inside this group
+     * @param {string} description
+     * @param {() => void} callback
+     */
     suite.only = (description, callback) => {
         onlyInScope = true;
         groups.push(description);

--- a/src/loader.js
+++ b/src/loader.js
@@ -100,6 +100,14 @@ function loadSuite(suiteName, builder) {
     };
 
     /**
+     * Skip this test case
+     * @param {string} description
+     * @param {(config: import('./config').Config) => Promise<void>} run
+     * @param {TestOptions} options
+     */
+    test.skip = () => {};
+
+    /**
      * Create a group for test cases
      * @param {string} description
      * @param {() => void} callback
@@ -124,6 +132,13 @@ function loadSuite(suiteName, builder) {
         onlyInScope = false;
         groups.pop();
     };
+
+    /**
+     * Skip this group of test cases
+     * @param {string} description
+     * @param {() => void} callback
+     */
+    suite.skip = () => {};
 
     builder(test, suite);
     return only.length > 0 ? only : tests;

--- a/src/loader.js
+++ b/src/loader.js
@@ -53,12 +53,12 @@ async function importFile(file) {
  */
 
 /**
- * @typedef {{(name: string, callback: () => void): void, only: (name: string, callback: () => void): void} SuiteFn
+ * @typedef {{(name: string, callback: () => void): void, only: (name: string, callback: () => void): void} DescribeFn
  */
 
 /**
  * @param {string} suiteName
- * @param {(test: TestFn, suite: SuiteFn) => void} builder
+ * @param {(test: TestFn, suite: DescribeFn) => void} builder
  * @private
  */
 function loadSuite(suiteName, builder) {
@@ -112,7 +112,7 @@ function loadSuite(suiteName, builder) {
      * @param {string} description
      * @param {() => void} callback
      */
-    function suite(description, callback) {
+    function describe(description, callback) {
         groups.push(description);
         callback();
         groups.pop();
@@ -123,7 +123,7 @@ function loadSuite(suiteName, builder) {
      * @param {string} description
      * @param {() => void} callback
      */
-    suite.only = (description, callback) => {
+    describe.only = (description, callback) => {
         onlyInScope = true;
         groups.push(description);
 
@@ -138,9 +138,9 @@ function loadSuite(suiteName, builder) {
      * @param {string} description
      * @param {() => void} callback
      */
-    suite.skip = () => {};
+    describe.skip = () => {};
 
-    builder(test, suite);
+    builder(test, describe);
     return only.length > 0 ? only : tests;
 }
 
@@ -176,8 +176,8 @@ async function loadTests(args, testsDir, globPattern = '*.{js,cjs,mjs}') {
 
             let tc = await importFile(file);
 
-            if (typeof tc.runSuite === 'function') {
-                testCases.push(...loadSuite(t.name, tc.runSuite));
+            if (typeof tc.suite === 'function') {
+                testCases.push(...loadSuite(t.name, tc.suite));
             } else {
                 // ESM modules are readonly, so we need to create our own writable
                 // object.

--- a/tests/selftest_suite.js
+++ b/tests/selftest_suite.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'suite', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-f', 'suite$'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/2 tests passed/.test(stderr), 'finds 2 tests');
+}
+
+module.exports = {
+    description: 'Load multiple tests from the same file',
+    run,
+};

--- a/tests/selftest_suite_nested.js
+++ b/tests/selftest_suite_nested.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'suite', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-f', 'suite_nested$'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/6 tests passed/.test(stderr), 'finds 6 tests');
+}
+
+module.exports = {
+    description: 'Load multiple tests from nested suites',
+    run,
+};

--- a/tests/selftest_suite_nested_only.js
+++ b/tests/selftest_suite_nested_only.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'suite', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-f', 'suite_nested_only$'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/2 tests passed/.test(stderr), 'finds 2 tests');
+}
+
+module.exports = {
+    description: 'Load multiple tests from nested suites',
+    run,
+};

--- a/tests/selftest_suite_only.js
+++ b/tests/selftest_suite_only.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'suite', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-f', '^only'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/1 tests passed/.test(stderr), 'Only runs 1 test');
+}
+
+module.exports = {
+    description: 'Load multiple tests from the same file',
+    run,
+};

--- a/tests/selftest_suite_skip.js
+++ b/tests/selftest_suite_skip.js
@@ -1,0 +1,24 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'suite', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-f', '^skip'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/3 tests passed/.test(stderr), 'Only runs 3 tests');
+}
+
+module.exports = {
+    description: 'Don\'t run skipped test in a suite',
+    run,
+};

--- a/tests/suite/only.js
+++ b/tests/suite/only.js
@@ -1,12 +1,12 @@
 /**
  * @param {import('../../loader').TestFn} test
  */
-function runSuite(test) {
+function suite(test) {
     test('Test A', () => {});
     test('Test B', () => {});
     test.only('Test C', () => {});
 }
 
 module.exports = {
-    runSuite,
+    suite,
 };

--- a/tests/suite/only.js
+++ b/tests/suite/only.js
@@ -1,0 +1,12 @@
+/**
+ * @param {import('../../loader').TestFn} test
+ */
+function runSuite(test) {
+    test('Test A', () => {});
+    test('Test B', () => {});
+    test.only('Test C', () => {});
+}
+
+module.exports = {
+    runSuite,
+};

--- a/tests/suite/run
+++ b/tests/suite/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});

--- a/tests/suite/skip.js
+++ b/tests/suite/skip.js
@@ -1,15 +1,15 @@
 /**
  * @param {import('../../src/loader').TestFn} test
  */
-function runSuite(test, suite) {
+function suite(test, describe) {
     test('Test A', () => {});
     test.skip('Test B', () => {});
 
-    suite('Group 1', () => {
+    describe('Group 1', () => {
         test('Test 1.A', () => {});
         test('Test 1.B', () => {});
 
-        suite.skip('Group 1.1', () => {
+        describe.skip('Group 1.1', () => {
             test('Test 1.1.A', () => {});
             test('Test 1.1.B', () => {});
         });
@@ -17,5 +17,5 @@ function runSuite(test, suite) {
 }
 
 module.exports = {
-    runSuite,
+    suite,
 };

--- a/tests/suite/skip.js
+++ b/tests/suite/skip.js
@@ -1,0 +1,21 @@
+/**
+ * @param {import('../../src/loader').TestFn} test
+ */
+function runSuite(test, suite) {
+    test('Test A', () => {});
+    test.skip('Test B', () => {});
+
+    suite('Group 1', () => {
+        test('Test 1.A', () => {});
+        test('Test 1.B', () => {});
+
+        suite.skip('Group 1.1', () => {
+            test('Test 1.1.A', () => {});
+            test('Test 1.1.B', () => {});
+        });
+    });
+}
+
+module.exports = {
+    runSuite,
+};

--- a/tests/suite/suite.js
+++ b/tests/suite/suite.js
@@ -1,0 +1,11 @@
+/**
+ * @param {import('../../src/loader').TestFn} test
+ */
+function runSuite(test) {
+    test('Test A', () => {});
+    test('Test B', () => {});
+}
+
+module.exports = {
+    runSuite,
+};

--- a/tests/suite/suite.js
+++ b/tests/suite/suite.js
@@ -1,11 +1,11 @@
 /**
  * @param {import('../../src/loader').TestFn} test
  */
-function runSuite(test) {
+function suite(test) {
     test('Test A', () => {});
     test('Test B', () => {});
 }
 
 module.exports = {
-    runSuite,
+    suite,
 };

--- a/tests/suite/suite_nested.js
+++ b/tests/suite/suite_nested.js
@@ -1,15 +1,15 @@
 /**
  * @param {import('../../src/loader').TestFn} test
  */
-function runSuite(test, suite) {
+function suite(test, describe) {
     test('Test A', () => {});
     test('Test B', () => {});
 
-    suite('Group 1', () => {
+    describe('Group 1', () => {
         test('Test 1.A', () => {});
         test('Test 1.B', () => {});
 
-        suite('Group 1.1', () => {
+        describe('Group 1.1', () => {
             test('Test 1.1.A', () => {});
             test('Test 1.1.B', () => {});
         });
@@ -17,5 +17,5 @@ function runSuite(test, suite) {
 }
 
 module.exports = {
-    runSuite,
+    suite,
 };

--- a/tests/suite/suite_nested.js
+++ b/tests/suite/suite_nested.js
@@ -1,0 +1,21 @@
+/**
+ * @param {import('../../src/loader').TestFn} test
+ */
+function runSuite(test, suite) {
+    test('Test A', () => {});
+    test('Test B', () => {});
+
+    suite('Group 1', () => {
+        test('Test 1.A', () => {});
+        test('Test 1.B', () => {});
+
+        suite('Group 1.1', () => {
+            test('Test 1.1.A', () => {});
+            test('Test 1.1.B', () => {});
+        });
+    });
+}
+
+module.exports = {
+    runSuite,
+};

--- a/tests/suite/suite_nested_only.js
+++ b/tests/suite/suite_nested_only.js
@@ -2,15 +2,15 @@
  * @param {import('../../src/loader').TestFn} test
  * @param {import('../../src/loader').DescribeFn} test
  */
-function runSuite(test, suite) {
+function suite(test, describe) {
     test('Test A', () => {});
     test('Test B', () => {});
 
-    suite('Group 1', () => {
+    describe('Group 1', () => {
         test('Test 1.A', () => {});
         test('Test 1.B', () => {});
 
-        suite.only('Group 1.1', () => {
+        describe.only('Group 1.1', () => {
             test('Test 1.1.A', () => {});
             test('Test 1.1.B', () => {});
         });
@@ -18,5 +18,5 @@ function runSuite(test, suite) {
 }
 
 module.exports = {
-    runSuite,
+    suite,
 };

--- a/tests/suite/suite_nested_only.js
+++ b/tests/suite/suite_nested_only.js
@@ -1,0 +1,22 @@
+/**
+ * @param {import('../../src/loader').TestFn} test
+ * @param {import('../../src/loader').DescribeFn} test
+ */
+function runSuite(test, suite) {
+    test('Test A', () => {});
+    test('Test B', () => {});
+
+    suite('Group 1', () => {
+        test('Test 1.A', () => {});
+        test('Test 1.B', () => {});
+
+        suite.only('Group 1.1', () => {
+            test('Test 1.1.A', () => {});
+            test('Test 1.1.B', () => {});
+        });
+    });
+}
+
+module.exports = {
+    runSuite,
+};


### PR DESCRIPTION
This PR adds support for a suite API to add multiple tests inside a single file.

```js
function suite(test, describe {
    test('Test A', () => {});
    test('Test B', () => {});

    describe('Group 1', () => {
        test('Test 1.A', () => {});
        test('Test 1.B', () => {});

        describe.only('Group 1.1', () => {
            test('Test 1.1.A', () => {});
            test('Test 1.1.B', () => {});
        });
    });
}

module.exports = {
    suite,
};
```