### PR TITLE
Add --tests-glob argument

### DIFF
--- a/config.js
+++ b/config.js
@@ -210,6 +210,11 @@ function parseArgs(options, raw_args) {
         dest: 'include_slow_tests',
         help: 'Run tests that take a very long time',
     });
+    selection_group.addArgument(['--tests-glob'], {
+        dest: 'testsGlob',
+        defaultValue: undefined,
+        help: 'Glob pattern to use when searching test files',
+    });
 
     const email_group = parser.addArgumentGroup({title: 'Email'});
     email_group.addArgument(['--keep-emails'], {

--- a/main.js
+++ b/main.js
@@ -51,7 +51,7 @@ async function real_main(options={}) {
         process.env.NODE_DISABLE_COLORS = 'true';
     }
 
-    const test_cases = await loadTests(args, options.testsDir, options.testsGlob);
+    const test_cases = await loadTests(args, options.testsDir, config.testsGlob || options.testsGlob);
     config._testsDir = options.testsDir;
     if (options.rootDir) config._rootDir = options.rootDir;
     if (options.configDir) config._configDir = options.configDir;

--- a/tests/selftest_glob.js
+++ b/tests/selftest_glob.js
@@ -1,0 +1,26 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    // Run in subprocess so that handle exhaustion does not affect this process
+    const sub_run = path.join(__dirname, 'glob_tests', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '--tests-glob', '*.spec.js'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/1 tests passed/.test(stderr), '1 test should pass');
+}
+
+module.exports = {
+    description: 'Test glob options',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
This PR adds support for `--tests-glob` which was previously only limited to an option that could be passed to `pentf.main(...)`.