### PR TITLE
Print last successful fn call on timeout error

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -195,7 +195,9 @@ function getDefaultTimeout(pageOrFrame) {
  */
 function addBreadcrumb(pageOrFrame, name) {
     const config =  getBrowser(pageOrFrame)._pentf_config;
-    config._breadcrumb = new Error(`Last successful browser operation was "${name}"`);
+    if (config.breadcrumbs) {
+        config._breadcrumb = new Error(`Last successful browser operation was "${name}"`);
+    }
 }
 
 /**

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -30,7 +30,7 @@ let tmp_home;
  * await waitForText(page, 'More information');
  * await closePage(page);
  * ```
- * @param {*} config The pentf configuration object.
+ * @param {import('./runner').TaskConfig} config The pentf configuration object.
  * @param {string[]} [chrome_args] Additional arguments for Chrome (optional).
  * @returns {import('puppeteer').Page} The puppeteer page handle.
  */
@@ -159,6 +159,7 @@ async function newPage(config, chrome_args=[]) {
     // The Browser instance is the nearest shared ancestor across pages
     // and frames.
     browser._pentf_config = config;
+    addBreadcrumb(page, 'newPage()');
 
     return page;
 }
@@ -186,6 +187,18 @@ function getDefaultTimeout(pageOrFrame) {
 }
 
 /**
+ * Mark progress in test. Useful for when the test times out and there is no
+ * hint as to why.
+ * @param {import('puppeteer').Page | import('puppeteer').Frame} pageOrFrame
+ * @param {string} name
+ * @private
+ */
+function addBreadcrumb(pageOrFrame, name) {
+    const config =  getBrowser(pageOrFrame)._pentf_config;
+    config._breadcrumb = new Error(`Last successful browser operation was "${name}"`);
+}
+
+/**
  * Close a page (and its associated browser)
  * @param {import('puppeteer').Page} page puppeteer page object returned by `newPage`.
  */
@@ -203,6 +216,7 @@ async function closePage(page) {
 
     await timeoutPromise(config, page.close(), {message: 'Closing the page took too long'});
     await timeoutPromise(config, browser.close(), {message: 'Closing the browser took too long'});
+    addBreadcrumb(page, 'closePage()');
 }
 
 /**
@@ -247,6 +261,7 @@ async function waitForVisible(page, selector, {message=undefined, timeout=getDef
         }
     }
     assert(el !== null);
+    addBreadcrumb(page, `waitForVisible(${selector})`);
     return el;
 }
 
@@ -306,7 +321,9 @@ async function waitForText(page, text, {timeout=getDefaultTimeout(page), extraMe
 
     const xpath = `//text()[contains(., ${escapeXPathText(text)})]`;
     try {
-        return await page.waitForXPath(xpath, {timeout});
+        const res = await page.waitForXPath(xpath, {timeout});
+        addBreadcrumb(page, `waitForText(${text})`);
+        return res;
     } catch (e) {
         throw err;
     }
@@ -352,6 +369,7 @@ async function waitForTestId(page, testId, {extraMessage=undefined, timeout=getD
         throw err; // Do not construct error here lest stack trace gets lost
     }
     assert(el !== null);
+    addBreadcrumb(page, `waitForTestId(${testId})`);
     return el;
 }
 
@@ -368,6 +386,7 @@ async function assertValue(input, expected) {
         await page.waitForFunction((inp, expected) => {
             return inp.value === expected;
         }, {timeout: 2000}, input, expected);
+        addBreadcrumb(page, `assertValue(${expected})`);
     } catch (e) {
         if (e.name !== 'TimeoutError') throw e;
 
@@ -438,6 +457,7 @@ async function assertNotXPath(page, xpath, options, _timeout=2000, _checkEvery=2
         await wait(Math.min(checkEvery, remainingTimeout));
         remainingTimeout -= checkEvery;
     }
+    addBreadcrumb(page, `assertNotXPath(${xpath})`);
 }
 
 /**
@@ -472,6 +492,7 @@ async function clickSelector(page, selector, {timeout=getDefaultTimeout(page), c
         }, selector, visible);
 
         if (found) {
+            addBreadcrumb(page, `clickSelector(${selector})`);
             return;
         }
 
@@ -521,6 +542,7 @@ async function clickXPath(page, xpath, {timeout=getDefaultTimeout(page), checkEv
         }, xpath, visible);
 
         if (found) {
+            addBreadcrumb(page, `clickXPath(${xpath})`);
             return;
         }
 
@@ -556,11 +578,13 @@ async function clickText(page, text, {timeout=getDefaultTimeout(page), checkEver
         elementXPath +
         `[contains(text(), ${escapeXPathText(text)})]`);
     const extraMessageRepr = extraMessage ? ` (${extraMessage})` : '';
-    return clickXPath(page, xpath, {
+    const res = await clickXPath(page, xpath, {
         timeout,
         checkEvery,
         message: `Unable to find text ${JSON.stringify(text)} after ${timeout}ms${extraMessageRepr}`,
     });
+    addBreadcrumb(page, `clickText(${text})`);
+    return res;
 }
 
 /**
@@ -649,6 +673,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=getDefaultTimeout(pa
         }, serializedMatcher, visible);
 
         if (found) {
+            addBreadcrumb(page, `clickNestedText(${textOrRegExp})`);
             return;
         }
 
@@ -677,7 +702,9 @@ async function clickTestId(page, testId, {extraMessage=undefined, timeout=getDef
     const xpath = `//*[@data-testid="${testId}"]`;
     const extraMessageRepr = extraMessage ? `. ${extraMessage}` : '';
     const message = `Failed to find${visible ? ' visible' : ''} element with data-testid "${testId}" within ${timeout}ms${extraMessageRepr}`;
-    return await clickXPath(page, xpath, {timeout, message, visible});
+    const res = await clickXPath(page, xpath, {timeout, message, visible});
+    addBreadcrumb(page, `clickTestId(${testId})`);
+    return res;
 }
 
 /**
@@ -692,6 +719,7 @@ async function clickTestId(page, testId, {extraMessage=undefined, timeout=getDef
 async function typeSelector(page, selector, text, {message=undefined, timeout=getDefaultTimeout(page)}={}) {
     const el = await waitForVisible(page, selector, {timeout, message});
     await el.type(text);
+    addBreadcrumb(page, `typeSelector(${selector}, text: ${text})`);
 }
 
 /**
@@ -724,6 +752,7 @@ async function setLanguage(page, lang) {
             }
         });
     }, lang);
+    addBreadcrumb(page, `setLanguage(${lang.join(', ')})`);
 }
 
 /**
@@ -736,7 +765,7 @@ async function setLanguage(page, lang) {
  */
 async function getAttribute(page, selector, name) {
     await page.waitForSelector(selector);
-    return page.$eval(
+    const res = await page.$eval(
         selector,
         (el, propName) => {
             if (propName in el) {
@@ -747,6 +776,8 @@ async function getAttribute(page, selector, name) {
         },
         name,
     );
+    addBreadcrumb(page, `getAttribute(${selector}, attr: ${name})`);
+    return res;
 }
 
 /**
@@ -757,7 +788,9 @@ async function getAttribute(page, selector, name) {
  * @returns {Promise<string>} Text content of the selected element.
  */
 async function getText(page, selector) {
-    return getAttribute(page, selector, 'textContent');
+    const res = await getAttribute(page, selector, 'textContent');
+    addBreadcrumb(page, `getText(${selector})`);
+    return res;
 }
 
 /**
@@ -932,4 +965,5 @@ module.exports = {
     waitForTestId,
     waitForText,
     waitForVisible,
+    workaround_setContent
 };

--- a/config.js
+++ b/config.js
@@ -331,6 +331,10 @@ function parseArgs(options, raw_args) {
         dest: 'status_interval',
         help: 'Interval in MS to print a detailed list of the current runner state.',
     });
+    runner_group.addArgument(['--breadcrumbs'], {
+        help: 'Keep track of the last successful browser operation (breadcrumbs). This helps with debugging test cases that timed out.',
+        action: 'storeTrue',
+    });
 
     const locking_group = parser.addArgumentGroup({title: 'Locking'});
     locking_group.addArgument(['-L', '--no-locking'], {
@@ -435,7 +439,7 @@ async function readConfigFile(configDir, env) {
 }
 
 /**
- * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream}} Config
+ * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean}} Config
  */
 
 /**

--- a/output.js
+++ b/output.js
@@ -606,6 +606,19 @@ async function logTaskError(config, task) {
                 config,
                 `${label} test case ${name} at ${utils.localIso8601()}:\n` +
                 `${await formatError(config, e)}\n`);
+
+            // There won't be a useful stack trace if the test timed out.
+            // Display collected breadcrumb additionally if there is one.
+            if (/Timeout:\sTest\scase/.test(e.message)) {
+                if (task.breadcrumb) {
+                    log(
+                        config,
+                        `${await formatError(config, task.breadcrumb)}\n`
+                    );
+                } else {
+                    log(config, '  No breadcrumbs were collected.\n');
+                }
+            }
         }
     }
 }

--- a/runner.js
+++ b/runner.js
@@ -36,6 +36,7 @@ function onTeardown(config, callback) {
  * @typedef {Object} RawTaskConfig
  * @property {TeardownHook[]} _teardown_hooks
  * @property {import('puppeteer').Page[]} _browser_pages
+ * @property {Error | null} _breadcrumb
  * @property {string} _testName
  * @property {string} _taskName
  */
@@ -55,6 +56,7 @@ async function run_task(config, task) {
         ...config,
         _teardown_hooks: [],
         _browser_pages: [],
+        _breadcrumb: null,
         _testName: task.tc.name,
         _taskName: task.name,
     };
@@ -103,6 +105,7 @@ async function run_task(config, task) {
 
         task.duration = performance.now() - task.start;
         task.error = e;
+        task.breadcrumb = task_config._breadcrumb;
         if (e.pentf_expectedToFail) {
             task.expectedToFail = e.pentf_expectedToFail;
         }
@@ -376,6 +379,7 @@ async function parallel_run(config, state) {
  * @property {string} name
  * @property {TestCase} tc
  * @property {TaskStatus} status
+ * @property {Error | null} breadcrumb
  * @property {boolean} [skipReason]
  * @property {boolean | ((config: import('./config').Config) => boolean)} [expectedToFail]
  */
@@ -426,6 +430,7 @@ async function testCases2tasks(config, testCases) {
         for (let runId = 0;runId < repeat;runId++) {
             tasks[runId * testCases.length + position] = {
                 ...task,
+                breadcrumb: null,
                 id: `${tc.name}_${runId}`,
                 name: `${tc.name}[${runId}]`,
             };

--- a/tests/selftest_breadcrumb.js
+++ b/tests/selftest_breadcrumb.js
@@ -29,8 +29,10 @@ const {
 async function execRunner(config, expected, fn) {
     const name = `${config._taskName}[${expected}]`;
     const output = [];
+    /** @type {import('../config').Config} */
     const runnerConfig = {
         ...config,
+        breadcrumbs: true,
         logFunc(config, message) {
             output.push(kolorist.stripColors(message));
         },

--- a/tests/selftest_breadcrumb.js
+++ b/tests/selftest_breadcrumb.js
@@ -1,0 +1,157 @@
+const assert = require('assert').strict;
+const runner = require('../runner');
+const kolorist = require('kolorist');
+const {
+    newPage,
+    closePage,
+    waitForVisible,
+    waitForText,
+    waitForTestId,
+    assertValue,
+    assertNotXPath,
+    clickSelector,
+    clickXPath,
+    clickText,
+    clickNestedText,
+    clickTestId,
+    typeSelector,
+    setLanguage,
+    getAttribute,
+    getText,
+    workaround_setContent,
+} = require('../browser_utils');
+
+/**
+ * @param {import('../runner').TaskConfig} config
+ * @param {string} expected
+ * @param {(config: import('../config').Config => Promise<void>)} fn
+ */
+async function execRunner(config, expected, fn) {
+    const name = `${config._taskName}[${expected}]`;
+    const output = [];
+    const runnerConfig = {
+        ...config,
+        logFunc(config, message) {
+            output.push(kolorist.stripColors(message));
+        },
+    };
+
+    await runner.run(runnerConfig, [
+        {
+            name,
+            run: async config => {
+                await fn(config);
+                throw new Error(`Timeout: Test case ${name}`);
+            },
+        },
+    ]);
+
+    assertOutput(output.join('\n'), expected);
+}
+
+function assertOutput(output, str) {
+    assert(
+        output.includes(`Last successful browser operation was "${str}"`),
+        `Expected output to include "${str}".\n\nOutput was: ${output}`
+    );
+}
+
+async function run(config) {
+    await execRunner(config, 'newPage()', async config => {
+        await newPage(config);
+    });
+
+    await execRunner(config, 'closePage()', async config => {
+        const page = await newPage(config);
+        await closePage(page);
+    });
+
+    await execRunner(config, 'waitForVisible(div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div>foo</div>');
+        await waitForVisible(page, 'div');
+    });
+
+    await execRunner(config, 'waitForText(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div>foo</div>');
+        await waitForText(page, 'foo');
+    });
+
+    await execRunner(config, 'waitForTestId(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div data-testid="foo">foo</div>');
+        await waitForTestId(page, 'foo');
+    });
+
+    await execRunner(config, 'assertValue(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<input value="foo" />');
+        const input = await page.$('input');
+        await assertValue(input, 'foo');
+    });
+
+    await execRunner(config, 'assertNotXPath(//span)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div></div>');
+        await assertNotXPath(page, '//span');
+    });
+
+    await execRunner(config, 'clickSelector(button)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button>foo</button>');
+        await clickSelector(page, 'button');
+    });
+
+    await execRunner(config, 'clickXPath(//button)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button>foo</button>');
+        await clickXPath(page, '//button');
+    });
+
+    await execRunner(config, 'clickText(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button>foo</button>');
+        await clickText(page, 'foo');
+    });
+
+    await execRunner(config, 'clickNestedText(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button>foo</button>');
+        await clickNestedText(page, 'foo');
+    });
+
+    await execRunner(config, 'clickTestId(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button data-testid="foo">foo</button>');
+        await clickTestId(page, 'foo');
+    });
+
+    await execRunner(config, 'typeSelector(input, text: foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<input />');
+        await typeSelector(page, 'input', 'foo');
+    });
+
+    await execRunner(config, 'setLanguage(foo)', async config => {
+        const page = await newPage(config);
+        await setLanguage(page, 'foo');
+    });
+
+    await execRunner(config, 'getAttribute(div, attr: class)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div class="foo"></div>');
+        await getAttribute(page, 'div', 'class');
+    });
+
+    await execRunner(config, 'getText(div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div class="foo"></div>');
+        await getText(page, 'div');
+    });
+}
+
+module.exports = {
+    run,
+    description: 'Display breadcrumb on timeout error',
+};


### PR DESCRIPTION
Test cases which error due to running longer than the allowed time limit are hard to debug as we have no clue where it hanged. With this PR we always save the last successful operation and print that when we run over the timeout limit.

Note that this only works for our own operations. There is no way to hook into the native ones from `puppeteer` as far as I can tell.

Example:

<img width="1067" alt="Screenshot 2020-08-03 at 19 34 57" src="https://user-images.githubusercontent.com/1062408/89210739-f17a9080-d5c0-11ea-897c-b737d71df3b7.png">
