### PR TITLE
Add enter/exit breadcrumbs

### DIFF
--- a/runner.js
+++ b/runner.js
@@ -59,6 +59,7 @@ async function run_task(config, task) {
         _breadcrumb: null,
         _testName: task.tc.name,
         _taskName: task.name,
+        start: task.start,
     };
     let timeout;
     try {
@@ -379,6 +380,7 @@ async function parallel_run(config, state) {
  * @property {string} name
  * @property {TestCase} tc
  * @property {TaskStatus} status
+ * @property {number} start
  * @property {Error | null} breadcrumb
  * @property {boolean} [skipReason]
  * @property {boolean | ((config: import('./config').Config) => boolean)} [expectedToFail]
@@ -402,6 +404,7 @@ async function testCases2tasks(config, testCases) {
             status: 'todo',
             name: tc.name,
             id: tc.name,
+            start: 0,
         };
 
         const skipReason = tc.skip && await tc.skip(config);

--- a/tests/selftest_breadcrumb.js
+++ b/tests/selftest_breadcrumb.js
@@ -27,7 +27,7 @@ const {
  * @param {(config: import('../config').Config => Promise<void>)} fn
  */
 async function execRunner(config, expected, fn) {
-    const name = `${config._taskName}[${expected}]`;
+    const name = `${config._taskName}[${expected}]`.replace(/[/:]/g, '_');
     const output = [];
     /** @type {import('../config').Config} */
     const runnerConfig = {
@@ -53,8 +53,8 @@ async function execRunner(config, expected, fn) {
 
 function assertOutput(output, str) {
     assert(
-        output.includes(`Last successful browser operation was "${str}"`),
-        `Expected output to include "${str}".\n\nOutput was: ${output}`
+        output.includes(`breadcrumb "exit ${str}"`),
+        `Expected output to include "exit ${str}".\n\nOutput was: ${output}`
     );
 }
 
@@ -150,6 +150,70 @@ async function run(config) {
         const page = await newPage(config);
         await workaround_setContent(page, '<div class="foo"></div>');
         await getText(page, 'div');
+    });
+
+    // Should add breadcrumbs to native page functions
+    await execRunner(config, 'page.goto(https://example.com)', async config => {
+        const page = await newPage(config);
+        await page.goto('https://example.com');
+    });
+
+    await execRunner(config, 'page.$(div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.$('div');
+    });
+
+    await execRunner(config, 'page.$$(div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.$$('div');
+    });
+
+    await execRunner(config, 'page.$eval()', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.$eval('div', () => null);
+    });
+
+    await execRunner(config, 'page.$$eval()', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.$$eval('div', () => null);
+    });
+
+    await execRunner(config, 'page.click(button)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<button />');
+        await page.click('button');
+    });
+
+    await execRunner(config, 'page.evaluate()', async config => {
+        const page = await newPage(config);
+        await page.evaluate(() => null);
+    });
+
+    await execRunner(config, 'page.type(input, foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<input />');
+        await page.type('input', 'foo');
+    });
+
+    await execRunner(config, 'page.waitForSelector(div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.waitForSelector('div');
+    });
+
+    await execRunner(config, 'page.waitForFunction()', async config => {
+        const page = await newPage(config);
+        await page.waitForFunction(() => true);
+    });
+
+    await execRunner(config, 'page.waitForXPath(//div)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div />');
+        await page.waitForXPath('//div');
     });
 }
 


### PR DESCRIPTION
This PR collects more detailed breadcrumbs if that feature is enabled. The distinction between exit and enter functions should make it more clear what the last breadcrumb represents. On top of that we wrap common puppeteer `Page` functions in case an error happens somewhere inside `puppeteer` itself.