### PR TITLE
Add assertNotSelector function

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -558,6 +558,32 @@ async function clickSelector(page, selector, {timeout=getDefaultTimeout(page), c
 }
 
 /**
+ * Asserts that a selector is not present in the passed page or frame.
+ *
+ * @example
+ * ```javascript
+ * await assertNotSelector(page, 'div[data-id="foo"] a.view', {message: 'Expected foo to not be present'});
+ * ```
+ * @param {import('puppeteer').Page} page puppeteer page object.
+ * @param {string} selector [CSS selector](https://www.w3.org/TR/2018/REC-selectors-3-20181106/#selectors) (aka query selector) of the targeted element.
+ * @param {{timeout?: number, message?: string}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {string?} message Error message shown if the element is not visible in time.
+ * @param {number?} timeout How long to wait, in milliseconds.
+ */
+async function assertNotSelector(page, selector, {timeout=getDefaultTimeout(page), message} = {}) {
+    const config = getBrowser(page)._pentf_config;
+    addBreadcrumb(config, `enter assertNotSelector(${selector})`);
+    try {
+        await page.waitForSelector(selector, {timeout});
+    } catch(err) {
+        addBreadcrumb(config, `exit assertNotSelector(${selector})`);
+        return;
+    }
+
+    throw new Error(`Element matching ${selector} is present, but should not be there. ${message ? ' ' + message : ''}`);
+}
+
+/**
  * Clicks an element addressed by XPath atomically, e.g. within the same event loop run as finding it.
  *
  * ```javascript
@@ -1037,6 +1063,7 @@ async function html2pdf(config, path, html, modifyPage=null) {
 }
 
 module.exports = {
+    assertNotSelector,
     assertNotTestId,
     assertNotXPath,
     assertValue,

--- a/tests/selftest_assertNotSelector.js
+++ b/tests/selftest_assertNotSelector.js
@@ -1,0 +1,22 @@
+const assert = require('assert').strict;
+const { newPage, workaround_setContent, assertNotSelector } = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await workaround_setContent(page, '<div></div>');
+
+    await assertNotSelector(page, 'span', { timeout: 10 });
+
+    try {
+        await assertNotSelector(page, 'div', { timeout: 3000, message: 'foobar' });
+        throw new Error('assertNotSelector did not throw');
+    } catch (err) {
+        // success
+        assert(err.message.includes('foobar'), `Custom message "foobar" not found in "${err.message}"`);
+    }
+}
+
+module.exports = {
+    run,
+    description: 'Assert that a selector is not present.'
+};

--- a/tests/selftest_breadcrumb.js
+++ b/tests/selftest_breadcrumb.js
@@ -19,6 +19,7 @@ const {
     getAttribute,
     getText,
     workaround_setContent,
+    assertNotSelector,
     assertNotTestId,
 } = require('../browser_utils');
 
@@ -92,6 +93,12 @@ async function run(config) {
         await workaround_setContent(page, '<input value="foo" />');
         const input = await page.$('input');
         await assertValue(input, 'foo');
+    });
+
+    await execRunner(config, 'assertNotSelector(span)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div></div>');
+        await assertNotSelector(page, 'span', { timeout: 2000 });
     });
 
     await execRunner(config, 'assertNotTestId(foo)', async config => {


### PR DESCRIPTION
This PR adds a new `assertNotSelector` function, which checks for the abscence of a selector.