### PR TITLE
Add assertNotTestId function

### DIFF
--- a/browser_utils.js
+++ b/browser_utils.js
@@ -766,6 +766,34 @@ async function clickTestId(page, testId, {extraMessage=undefined, timeout=getDef
 }
 
 /**
+ * Asserts that an element identified by a test ID (`data-testid=` attribute) is not present in the passed page or frame.
+ *
+ * @example
+ * ```javascript
+ * await assertNotTestId(page, 'foo', {message: 'Expected Test ID "foo" to not be present'});
+ * ```
+ * @param {import('puppeteer').Page} page puppeteer page object.
+ * @param {string} testId The test ID to look for.
+ * @param {{timeout?: number, message?: string}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
+ * @param {string?} message Error message shown if the element is not visible in time.
+ * @param {number?} timeout How long to wait, in milliseconds.
+ */
+async function assertNotTestId(page, testId, {timeout=getDefaultTimeout(page), message} = {}) {
+    const config = getBrowser(page)._pentf_config;
+    addBreadcrumb(config, `enter assertNotTestId(${testId})`);
+    _checkTestId(testId);
+
+    const xpath = `//*[@data-testid="${testId}"]`;
+    try {
+        await assertNotXPath(page, xpath, {timeout});
+        addBreadcrumb(config, `exit assertNotTestId(${testId})`);
+    } catch (err) {
+        if (/Element\smatching/.test(err.message)) {
+            throw new Error(`Element matching test id "${testId}" is present, but should not be there. ${message ? ' ' + message : ''}`);
+        }
+    }
+}
+/**
  * Type text into an element identified by a query selector.
  *
  * @param {import('puppeteer').Page} page puppeteer page object.
@@ -1009,6 +1037,7 @@ async function html2pdf(config, path, html, modifyPage=null) {
 }
 
 module.exports = {
+    assertNotTestId,
     assertNotXPath,
     assertValue,
     clickNestedText,

--- a/tests/selftest_assertNotTestId.js
+++ b/tests/selftest_assertNotTestId.js
@@ -1,0 +1,22 @@
+const assert = require('assert').strict;
+const { newPage, workaround_setContent, assertNotTestId } = require('../browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await workaround_setContent(page, '<div data-testid="foobar"></div>');
+
+    await assertNotTestId(page, 'bar', { timeout: 10 });
+
+    try {
+        await assertNotTestId(page, 'foobar', { timeout: 3000, message: 'foobar' });
+        throw new Error('assertNotTestId did not throw');
+    } catch (err) {
+        // success
+        assert(err.message.includes('foobar'), `Custom message "foobar" not found in "${err.message}"`);
+    }
+}
+
+module.exports = {
+    run,
+    description: 'Assert that a Test ID is not present.'
+};

--- a/tests/selftest_breadcrumb.js
+++ b/tests/selftest_breadcrumb.js
@@ -19,6 +19,7 @@ const {
     getAttribute,
     getText,
     workaround_setContent,
+    assertNotTestId,
 } = require('../browser_utils');
 
 /**
@@ -91,6 +92,12 @@ async function run(config) {
         await workaround_setContent(page, '<input value="foo" />');
         const input = await page.$('input');
         await assertValue(input, 'foo');
+    });
+
+    await execRunner(config, 'assertNotTestId(foo)', async config => {
+        const page = await newPage(config);
+        await workaround_setContent(page, '<div></div>');
+        await assertNotTestId(page, 'foo', { timeout: 2000 });
     });
 
     await execRunner(config, 'assertNotXPath(//span)', async config => {


### PR DESCRIPTION
This PR adds a new `assertNotTestId` function, which checks for the abscence of a Test ID.