### PR TITLE
Fix wrong column offset with tab indentation

### DIFF
--- a/output.js
+++ b/output.js
@@ -495,7 +495,7 @@ function genCodeFrame(config, content, lineNum, columnNum, before, after) {
                 const formatted = `${marker} ${currentLine} | ${normalized}`;
 
                 // Account for possible tab indention
-                const count = (line.length - normalized.length) + columnNum - 1;
+                const count = (normalized.length - line.length) + columnNum - 1;
 
                 return formatted + `\n  ${padding} ${color(config, 'dim', '|')} ${' '.repeat(count)}${color(config, 'bold-red', '^')}`;
             } else {


### PR DESCRIPTION
We always replace any leading tab character with 2 spaces. The `normalized` version will be longer than the raw `line` if there were tabs. The variables were in the wrong order.