### PR TITLE
Close browser pages automatically on teardown

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -178,6 +178,18 @@ async function newPage(config, chrome_args=[]) {
     browser._pentf_config = config;
     addBreadcrumb(config, 'exit newPage()');
 
+    // PDF renderer invokes newPage with a raw config object which doesn't
+    // have runner sepcific properties
+    if (config._teardown_hooks) {
+        // Don't use onTeardown, because importing it would lead to a circular
+        // dependency.
+        config._teardown_hooks.push(async () => {
+            if (!page.isClosed()) {
+                await closePage(page);
+            }
+        });
+    }
+
     return page;
 }
 

--- a/tests/selftest_browser_close.js
+++ b/tests/selftest_browser_close.js
@@ -1,0 +1,31 @@
+const assert = require('assert').strict;
+const {newPage} = require('../browser_utils');
+const runner = require('../runner');
+
+async function run(config) {
+    let page;
+    const tasks = [
+        {
+            name: 'foo',
+            async run(config) {
+                page = await newPage(config);
+            },
+        },
+    ];
+
+    await runner.run(
+        {
+            quiet: true,
+            logFunc: () => null,
+            ...config,
+        },
+        tasks
+    );
+
+    assert(page.isClosed(), "Page wasn't closed during teardown");
+}
+
+module.exports = {
+    description: 'Close browser automatically on teardown',
+    run,
+};


### PR DESCRIPTION
This PR removes the need to have to call `closePage()`  explicitly at the end of each test where a browser was opened. Whenever a page is opened, it will be scheduled to be closed on teardown automatically if it is still open.

One can still close browsers via `closePage()` manually in tests like usual.