### PR TITLE
Fix skipped suite tests not visible in summary

### DIFF
--- a/tests/selftest_suite_skip.js
+++ b/tests/selftest_suite_skip.js
@@ -15,7 +15,8 @@ async function run() {
         );
     });
 
-    assert(/3 tests passed/.test(stderr), 'Only runs 3 tests');
+    assert(/3 tests passed/.test(stderr), 'Expected 3 tests to pass');
+    assert(/3 skipped/.test(stderr), 'Expected 3 tests to be marked as skipped');
 }
 
 module.exports = {


### PR DESCRIPTION
This PR fixes an issue where skipped tests of a suite would not show up in any runner logs or the summary at the end. The issue was caused by the suite loader simply ignoring skipped tests, instead of marking them as skipped and push them into the runner queue.