### PR TITLE
Fix pentf-version throwing in esm

### DIFF
--- a/babel-transform-commonjs-to-esm.js
+++ b/babel-transform-commonjs-to-esm.js
@@ -18,178 +18,268 @@ function moveComments(node, target) {
 module.exports = function cjs2esm({types: t}) {
     return {
         visitor: {
-            Program(path, state) {
-                // If there is no top-level expression, then there is no
-                // module.exports assignment
-                const moduleExpIdx = path.node.body.findIndex(
-                    node =>
-                        t.isExpressionStatement(node) &&
-                        t.isAssignmentExpression(node.expression) &&
-                        node.expression.operator === '='
-                );
-                const moduleExp = path.node.body[moduleExpIdx];
-                if (
-                    !moduleExp ||
-                    !t.isMemberExpression(moduleExp.expression.left) ||
-                    !t.isObjectExpression(moduleExp.expression.right)
-                ) {
-                    return;
-                }
-
-                // Check if we're dealing with `module.exports`
-                const member = moduleExp.expression.left;
-                if (
-                    !(
-                        t.isIdentifier(member.object) &&
-                        member.object.name === 'module' &&
-                        t.isIdentifier(member.property) &&
-                        member.property.name === 'exports'
-                    )
-                ) {
-                    return;
-                }
-
-                // Collect a list of export name -> reference maps
-                const fns = new Map();
-                const requires = new Map();
-                const vars = [];
-                path.node.body.forEach((node, i) => {
-                    if (t.isFunctionDeclaration(node)) {
-                        fns.set(node.id.name, {i, node});
-                    } else if (
-                        t.isVariableDeclaration(node) &&
-                        node.declarations.length === 1 &&
-                        node.declarations[0].init !== null
+            Program: {
+                exit(path, state) {
+                    // If there is no top-level expression, then there is no
+                    // module.exports assignment
+                    const moduleExpIdx = path.node.body.findIndex(
+                        node =>
+                            t.isExpressionStatement(node) &&
+                            t.isAssignmentExpression(node.expression) &&
+                            node.expression.operator === '='
+                    );
+                    const moduleExp = path.node.body[moduleExpIdx];
+                    if (
+                        !moduleExp ||
+                        !t.isMemberExpression(moduleExp.expression.left) ||
+                        !t.isObjectExpression(moduleExp.expression.right)
                     ) {
-                        const varDecl = node.declarations[0];
-                        const specifiers = [];
-                        let source;
-                        // Scenarios:
-                        // const a = require('./a');
-                        // const { a, b } = require('./a');
-                        if (isRequireCall(t, varDecl.init)) {
-                            source = varDecl.init.arguments[0];
-                            const left = varDecl.id;
-
-                            if (t.isObjectPattern(left)) {
-                                left.properties.forEach(prop => {
-                                    // Scenarios:
-                                    // import { foo } from 'bar';
-                                    // import { foo as bob } from 'bar';
-                                    if (t.isIdentifier(prop.key) && t.isIdentifier(prop.value)) {
-                                        specifiers.push(t.importSpecifier(prop.key, prop.value));
-                                        requires.set(prop.key.name, {i, node: varDecl});
-                                    } else {
-                                        throw new Error('Unsupported require statement');
-                                    }
-                                });
-                            } else if (t.isIdentifier(left)) {
-                                // Depending on whether node is run in ESM mode we may have to
-                                // account for default exports.
-                                //
-                                // ```js
-                                // import __foo from 'foo';
-                                // const foo = __foo.default || foo;
-                                // ```
-                                const leftImported = t.identifier(`__${left.name}`);
-                                specifiers.push(t.importNamespaceSpecifier(leftImported));
-
-                                vars.push(
-                                    t.variableDeclaration('const', [
-                                        t.variableDeclarator(
-                                            left,
-                                            t.logicalExpression(
-                                                '||',
-                                                t.memberExpression(
-                                                    leftImported,
-                                                    t.identifier('default')
-                                                ),
-                                                leftImported
-                                            )
-                                        ),
-                                    ])
-                                );
-                                requires.set(left.name, {i, node: varDecl});
-                            } else {
-                                throw new Error('Unsupported node');
-                            }
-                        }
-                        // Scenarios:
-                        // const a = require('./a').foo;
-                        else if (
-                            t.isMemberExpression(varDecl.init) &&
-                            isRequireCall(t, varDecl.init.object)
-                        ) {
-                            source = varDecl.init.object.arguments[0];
-                            specifiers.push(t.importSpecifier(varDecl.id, varDecl.init.property));
-                        }
-
-                        if (source && specifiers.length > 0) {
-                            if (
-                                state.opts &&
-                                state.opts.extension &&
-                                source.value.startsWith('.')
-                            ) {
-                                source.value += state.opts.extension;
-                            }
-
-                            path.node.body[i] = t.importDeclaration(specifiers, source);
-                        }
+                        return;
                     }
-                });
 
-                const newImports = [];
-                const obj = moduleExp.expression.right;
-                obj.properties.forEach(prop => {
-                    if (!t.isIdentifier(prop.key) || !t.isIdentifier(prop.value)) {
-                        throw new Error(
-                            'Only references are supported right now in module.export statements'
+                    // Check if we're dealing with `module.exports`
+                    const member = moduleExp.expression.left;
+                    if (
+                        !(
+                            t.isIdentifier(member.object) &&
+                            member.object.name === 'module' &&
+                            t.isIdentifier(member.property) &&
+                            member.property.name === 'exports'
+                        )
+                    ) {
+                        return;
+                    }
+
+                    // Collect a list of export name -> reference maps
+                    const fns = new Map();
+                    const requires = new Map();
+                    const vars = [];
+                    path.node.body.forEach((node, i) => {
+                        if (t.isFunctionDeclaration(node)) {
+                            fns.set(node.id.name, {i, node});
+                        } else if (
+                            t.isVariableDeclaration(node) &&
+                            node.declarations.length === 1 &&
+                            node.declarations[0].init !== null
+                        ) {
+                            const varDecl = node.declarations[0];
+                            const specifiers = [];
+                            let source;
+                            // Scenarios:
+                            // const a = require('./a');
+                            // const { a, b } = require('./a');
+                            if (isRequireCall(t, varDecl.init)) {
+                                source = varDecl.init.arguments[0];
+                                const left = varDecl.id;
+
+                                if (t.isObjectPattern(left)) {
+                                    left.properties.forEach(prop => {
+                                        // Scenarios:
+                                        // import { foo } from 'bar';
+                                        // import { foo as bob } from 'bar';
+                                        if (
+                                            t.isIdentifier(prop.key) &&
+                                            t.isIdentifier(prop.value)
+                                        ) {
+                                            specifiers.push(
+                                                t.importSpecifier(prop.key, prop.value)
+                                            );
+                                            requires.set(prop.key.name, {i, node: varDecl});
+                                        } else {
+                                            throw new Error('Unsupported require statement');
+                                        }
+                                    });
+                                } else if (t.isIdentifier(left)) {
+                                    // Depending on whether node is run in ESM mode we may have to
+                                    // account for default exports.
+                                    //
+                                    // ```js
+                                    // import __foo from 'foo';
+                                    // const foo = __foo.default || foo;
+                                    // ```
+                                    const leftImported = t.identifier(`__${left.name}`);
+                                    specifiers.push(t.importNamespaceSpecifier(leftImported));
+
+                                    vars.push(
+                                        t.variableDeclaration('const', [
+                                            t.variableDeclarator(
+                                                left,
+                                                t.logicalExpression(
+                                                    '||',
+                                                    t.memberExpression(
+                                                        leftImported,
+                                                        t.identifier('default')
+                                                    ),
+                                                    leftImported
+                                                )
+                                            ),
+                                        ])
+                                    );
+                                    requires.set(left.name, {i, node: varDecl});
+                                } else {
+                                    throw new Error('Unsupported node');
+                                }
+                            }
+                            // Scenarios:
+                            // const a = require('./a').foo;
+                            else if (
+                                t.isMemberExpression(varDecl.init) &&
+                                isRequireCall(t, varDecl.init.object)
+                            ) {
+                                source = varDecl.init.object.arguments[0];
+                                specifiers.push(
+                                    t.importSpecifier(varDecl.id, varDecl.init.property)
+                                );
+                            }
+
+                            if (source && specifiers.length > 0) {
+                                if (
+                                    state.opts &&
+                                    state.opts.extension &&
+                                    source.value.startsWith('.')
+                                ) {
+                                    source.value += state.opts.extension;
+                                }
+
+                                path.node.body[i] = t.importDeclaration(specifiers, source);
+                            }
+                        }
+                    });
+
+                    const newImports = [];
+                    const obj = moduleExp.expression.right;
+                    obj.properties.forEach(prop => {
+                        if (!t.isIdentifier(prop.key) || !t.isIdentifier(prop.value)) {
+                            throw new Error(
+                                'Only references are supported right now in module.export statements'
+                            );
+                        }
+
+                        if (prop.key.name === prop.value.name) {
+                            const decl = fns.get(prop.key.name);
+                            if (!decl) {
+                                const reExport = requires.get(prop.key.name);
+                                if (!reExport) {
+                                    throw new Error(
+                                        `Function declaration for "${prop.key.name}" not found`
+                                    );
+                                }
+
+                                const source = reExport.node.init.arguments[0];
+
+                                const exportNode = t.exportNamedDeclaration(null, [
+                                    t.exportSpecifier(prop.key, prop.key),
+                                ]);
+                                path.node.body[reExport.i] = exportNode;
+
+                                const importNode = t.importDeclaration(
+                                    [t.importSpecifier(prop.key, prop.key)],
+                                    source
+                                );
+                                newImports.push(importNode);
+                            } else {
+                                const exportNode = t.exportNamedDeclaration(decl.node);
+                                moveComments(decl.node, exportNode);
+                                path.node.body[decl.i] = exportNode;
+                            }
+                        }
+                    });
+
+                    // Remove `module.exports` expression
+                    path.node.body.splice(moduleExpIdx, 1);
+
+                    // Add any new imports (mainly because of re-exports)
+                    newImports.forEach(importNode => {
+                        path.node.body.unshift(importNode);
+                    });
+
+                    // Add __dirname patch
+                    if (state.needsDirnamePatch) {
+                        if (!state.hasPathModule) {
+                            path.node.body.unshift(
+                                t.importDeclaration(
+                                    [t.importNamespaceSpecifier(t.identifier('path'))],
+                                    t.stringLiteral('path')
+                                )
+                            );
+                        }
+
+                        const fileUrl = t.identifier('fileURLToPath');
+                        path.node.body.unshift(
+                            t.importDeclaration(
+                                [t.importSpecifier(fileUrl, fileUrl)],
+                                t.stringLiteral('url')
+                            )
                         );
                     }
 
-                    if (prop.key.name === prop.value.name) {
-                        const decl = fns.get(prop.key.name);
-                        if (!decl) {
-                            const reExport = requires.get(prop.key.name);
-                            if (!reExport) {
-                                throw new Error(
-                                    `Function declaration for "${prop.key.name}" not found`
-                                );
-                            }
+                    const varIdx = path.node.body.findIndex(node => !t.isImportDeclaration(node));
 
-                            const source = reExport.node.init.arguments[0];
+                    vars.forEach(decl => {
+                        path.node.body.splice(varIdx, 0, decl);
+                    });
 
-                            const exportNode = t.exportNamedDeclaration(null, [
-                                t.exportSpecifier(prop.key, prop.key),
-                            ]);
-                            path.node.body[reExport.i] = exportNode;
+                    // Add esm dirname patch
+                    if (state.needsDirnamePatch) {
+                        const patch = t.variableDeclaration('const', [
+                            t.variableDeclarator(
+                                t.identifier('__dirnameEsm'),
+                                t.arrowFunctionExpression(
+                                    [t.identifier('url')],
+                                    t.callExpression(
+                                        t.memberExpression(
+                                            t.identifier('path'),
+                                            t.identifier('dirname')
+                                        ),
+                                        [
+                                            t.callExpression(t.identifier('fileURLToPath'), [
+                                                t.identifier('url'),
+                                            ]),
+                                        ]
+                                    )
+                                )
+                            ),
+                        ]);
+                        path.node.body.splice(varIdx, 0, patch);
+                    }
+                },
+            },
 
-                            const importNode = t.importDeclaration(
-                                [t.importSpecifier(prop.key, prop.key)],
-                                source
-                            );
-                            newImports.push(importNode);
-                        } else {
-                            const exportNode = t.exportNamedDeclaration(decl.node);
-                            moveComments(decl.node, exportNode);
-                            path.node.body[decl.i] = exportNode;
+            CallExpression: {
+                enter(path, state) {
+                    // Check for `require('foo')`
+                    if (
+                        !t.isIdentifier(path.node.callee) ||
+                        path.node.callee.name !== 'require' ||
+                        path.node.arguments.length !== 1 ||
+                        !t.isStringLiteral(path.node.arguments[0])
+                    ) {
+                        return;
+                    }
+
+                    // Check if `path = require('path')` is present
+                    if (path.node.arguments[0].value === 'path') {
+                        if (t.isIdentifier(path.parentPath.node.id)) {
+                            state.hasPathModule = true;
                         }
                     }
-                });
+                },
+            },
 
-                // Remove `module.exports` expression
-                path.node.body.splice(moduleExpIdx, 1);
+            Identifier: {
+                enter(path, state) {
+                    if (path.node.name !== '__dirname') return;
 
-                // Add any new imports (mainly because of re-exports)
-                newImports.forEach(importNode => {
-                    path.node.body.unshift(importNode);
-                });
-
-                const varIdx = path.node.body.findIndex(node => !t.isImportDeclaration(node));
-
-                vars.forEach(decl => {
-                    path.node.body.splice(varIdx, 0, decl);
-                });
+                    state.needsDirnamePatch = true;
+                    path.replaceWith(
+                        t.callExpression(t.identifier('__dirnameEsm'), [
+                            t.memberExpression(
+                                t.memberExpression(t.identifier('import'), t.identifier('meta')),
+                                t.identifier('url')
+                            ),
+                        ])
+                    );
+                },
             },
 
             Directive(path) {

--- a/src/version.js
+++ b/src/version.js
@@ -2,6 +2,7 @@ const child_process = require('child_process');
 const {promisify} = require('util');
 const {EOL} = require('os');
 const fs = require('fs');
+const path = require('path');
 
 async function _cmd(cmd, args, options) {
     return (await (promisify(child_process.execFile)(cmd, args, options))).stdout.trim();
@@ -44,7 +45,10 @@ function pentfVersion() {
     // that cannot be translated to ES Modules. For ES Modules
     // any inline `import()` call is asynchronous.
     // Work around that by invoking `fs.readFileSync()` instead.
-    return JSON.parse(fs.readFileSync('./package.json', 'utf-8')).version;
+    //
+    // The variable __dirname is not present in ESM environments.
+    // It will be replaced with a polyfill by our babel plugin.
+    return JSON.parse(fs.readFileSync(path.join(__dirname, '..', 'package.json'), 'utf-8')).version;
 }
 
 module.exports = {

--- a/tests/selftest_version_pentf.js
+++ b/tests/selftest_version_pentf.js
@@ -1,0 +1,24 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'version_pentf', 'run');
+    const {stdout} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--version'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/pentf \d+\.\d+\.\d+/.test(stdout), 'Version string not found');
+}
+
+module.exports = {
+    run,
+    description: 'Should print pentf version number'
+};

--- a/tests/version_pentf/run
+++ b/tests/version_pentf/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});


### PR DESCRIPTION
- It was pointing at the wrong target.
- `__dirname` is not available in ESM enviornments, use babel to add a polyfill