### PR TITLE
Add flaky test detection

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -320,6 +320,13 @@ function parseArgs(options, raw_args) {
         defaultValue: 1,
         help: 'Run the tests the specified number of times',
     });
+    runner_group.addArgument(['--repeat-flaky'], {
+        type: 'int',
+        metavar: 'COUNT',
+        defaultValue: 0,
+        help: 'Repeat a failing test until it passes or the specified run count limit is reached',
+        dest: 'repeatFlaky'
+    });
     runner_group.addArgument(['--timeout'], {
         type: 'int',
         metavar: 'MS',
@@ -440,7 +447,7 @@ async function readConfigFile(configDir, env) {
 }
 
 /**
- * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean}} Config
+ * @typedef {{no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number}} Config
  */
 
 /**

--- a/src/output.js
+++ b/src/output.js
@@ -181,7 +181,7 @@ function resultSummary(config, tasks, onTests=false) {
         res += color(config, 'red', `  ${pad(errored.length)} failed (${errored.map(s => s.name).join(', ')})\n`);
     }
     if (flaky.length) {
-        res += `  ${pad(flaky.length)} flaky\n`;
+        res += color(config, 'lightMagenta', `  ${pad(flaky.length)} flaky (${flaky.map(s => s.name).join(', ')})\n`);
     }
     if (skipped.length) {
         res += color(config, 'cyan',`  ${pad(skipped.length)} skipped (${skipped.map(s => s.name).join(', ')})\n`);

--- a/tests/selftest_flaky_detection.js
+++ b/tests/selftest_flaky_detection.js
@@ -1,0 +1,84 @@
+const assert = require('assert').strict;
+const runner = require('../src/runner');
+const render = require('../src/render');
+
+/**
+ * @param {import('../src/runner').TaskConfig} config
+ */
+async function run(config) {
+    const runnerConfig = {
+        ...config,
+        logFunc: () => null,
+        repeatFlaky: 3,
+        quiet: true,
+    };
+
+    function createTests() {
+        let i = 0;
+        let j = 0;
+        /** @type {import('../src/runner').TestCase[]} */
+        return [
+            {
+                name: 'foo',
+                run: async () => {
+                    i++;
+                    if (i < 3) {
+                        throw new Error('fail');
+                    }
+                },
+            },
+            {
+                name: 'bar',
+                run: async () => {
+                    throw new Error('fail');
+                },
+            },
+            {
+                name: 'baz',
+                run: async () => {},
+            },
+            {
+                name: 'bob',
+                run: async () => {
+                    j++;
+                    if (j < 2) {
+                        throw new Error('fail');
+                    }
+                },
+            },
+        ];
+    }
+
+    function assertResult(test_info) {
+        const result = render.craftResults(config, test_info);
+        const formatted = result.tests.map(t => {
+            return {
+                id: t.id,
+                status: t.status,
+                runs: t.taskResults.length,
+            };
+        });
+
+        assert.deepEqual(formatted, [
+            {id: 'bar', status: 'error', runs: 3},
+            {id: 'bob', status: 'flaky', runs: 2},
+            {id: 'foo', status: 'flaky', runs: 3},
+            {id: 'baz', status: 'success', runs: 1},
+        ]);
+    }
+
+    // Sequential run
+    let tests = createTests();
+    let result = await runner.run({...runnerConfig, concurrency: 1}, tests);
+    assertResult(result);
+
+    // Parallel run
+    tests = createTests();
+    result = await runner.run({...runnerConfig, concurrency: 1}, tests);
+    assertResult(result);
+}
+
+module.exports = {
+    run,
+    descripton: 'Rerun task when flakyness is detected',
+};


### PR DESCRIPTION
This PR adds a new command line flag to re-run failing tests the specified amount of time. If the test passes before reaching that limit it is marked as `flaky`. This should ensure that our tests remain green, even if there are hickups on the backend side. Note that the stack traces of flaky tests will still be logged and printed in the results report.

The running status output needs to be improved, because it's based on tasks instead of tests and therefore will never print tests as being flaky. In my opinion this is better left for another PR. Happy to do it here to, if requested.