### PR TITLE
Fix duplicate assert diff output

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -525,7 +525,9 @@ async function formatError(config, err) {
     let nearestFrame;
 
     // Assertion libraries often add multiline messages to the error stack.
-    const actualStack = err.stack.replace(`${err.name}: ${err.message}`, '');
+    const actualStack = err.stack
+        .replace(`${err.name}: ${err.message}`, '')
+        .replace(err.message, '');
 
     const stack = errorstacks.parseStackTrace(actualStack)
         .map(frame => {


### PR DESCRIPTION
Node's `assert` module appends the diff output not just to the error message, but also prepends it to the stack property. This PR corrects that, so that we don't show duplicate diff messages.