### PR TITLE
Refactor result + status to be based on tests

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -32,11 +32,11 @@ function clean(config) {
 function status(config, state) {
     if (config.quiet) return;
     assert(state.tasks);
-    assert(state.resultById);
+    assert(state.resultByTaskId);
 
     last_state = state;
 
-    const testResults = Array.from(state.resultById.values());
+    const testResults = Array.from(state.resultByTaskId.values());
     const {errored, expectedToFail, skipped} = getResults(config, testResults);
     const {tasks} = state;
 
@@ -112,7 +112,7 @@ function formatDuration(config, duration) {
  */
 function detailedStatus(config, state) {
     const {tasks} = state;
-    const testResults = Array.from(state.resultById.values());
+    const testResults = Array.from(state.resultByTaskId.values());
     const {skipped} = getResults(config, testResults);
 
     const done = tasks.filter(t => t.status === 'success' || t.status === 'error');
@@ -218,7 +218,7 @@ function finish(config, state) {
     if (tasks.length === 0 && config.filter) {
         msg += `No test case found with filter: ${config.filter}\n`;
     }
-    const testResults = Array.from(state.resultById.values());
+    const testResults = Array.from(state.resultByTaskId.values());
     const results = getResults(config, testResults);
     msg += resultSummary(config, results);
 

--- a/src/render.js
+++ b/src/render.js
@@ -61,7 +61,7 @@ function craftResults(config, test_info) {
     const {test_start, test_end, state, ...moreInfo} = test_info;
 
     /** @type {TestResult[]} */
-    const tests = Array.from(state.resultById.values());
+    const tests = Array.from(state.resultByTaskId.values());
 
     // Order tests by severity
     tests.sort((testA, testB) => {

--- a/src/results.js
+++ b/src/results.js
@@ -3,28 +3,23 @@ const assert = require('assert').strict;
 /**
  * Get tests result summary data
  * @param {import('./config').Config} config
- * @param {import('./runner').Task[]} tasks
- * @param {boolean} onTests
+ * @param {import('./render').TestResult[]} results
  * @private
  */
-function getResults(config, tasks, onTests=false) {
+function getResults(config, results) {
     const expectNothing = config.expect_nothing;
-    assert(Array.isArray(tasks));
+    assert(Array.isArray(results));
 
-    const success = tasks.filter(t => t.status === 'success' && (!t.expectedToFail || expectNothing));
-    const errored = tasks.filter(
+    const success = results.filter(t => t.status === 'success' && (!t.expectedToFail || expectNothing));
+    const errored = results.filter(
         t => t.status === 'error' && (!t.expectedToFail || expectNothing));
-    const flaky = tasks.filter(t => t.status === 'flaky');
-    const skipped = tasks.filter(t => t.status === 'skipped');
-    const expectedToFail = !expectNothing && tasks.filter(
+    const flaky = results.filter(t => t.status === 'flaky');
+    const skipped = results.filter(t => t.status === 'skipped');
+    const expectedToFail = !expectNothing && results.filter(
         t => t.expectedToFail && t.status === 'error');
-    const expectedToFailButPassed = !expectNothing && tasks.filter(
+    const expectedToFailButPassed = !expectNothing && results.filter(
         t => t.expectedToFail && t.status === 'success');
-    const running = tasks.filter(t => t.status === 'running');
-    const done = tasks.filter(t => (t.status === 'success') || (t.status === 'error'));
-    const todo = tasks.filter(t => t.status === 'todo');
-
-    const itemName = (onTests || ((config.repeat || 1) === 1)) ? 'tests' : 'tasks';
+    const todo = results.filter(t => t.status === 'todo');
 
     return {
         success,
@@ -33,9 +28,6 @@ function getResults(config, tasks, onTests=false) {
         skipped,
         expectedToFail,
         expectedToFailButPassed,
-        itemName,
-        running,
-        done,
         todo,
     };
 }
@@ -44,11 +36,10 @@ function getResults(config, tasks, onTests=false) {
 * Summarize test results for PDF.
 * @hidden
 * @param {*} config The pentf configuration object.
-* @param {Array<Object>} tasks All finished tasks.
-* @param {boolean} onTests Summarize tests instead of tasks.
+* @param {import('./render').TestResult[]} tests All finished tests.
 * @returns {string} A string with counts of the results.
 **/
-function resultCountString(config, tasks, onTests=false) {
+function resultCountString(config, tests) {
     const {
         success,
         errored,
@@ -56,10 +47,9 @@ function resultCountString(config, tasks, onTests=false) {
         skipped,
         expectedToFail,
         expectedToFailButPassed,
-        itemName
-    } = getResults(config, tasks, onTests);
+    } = getResults(config, tests);
 
-    let res = `${success.length} ${itemName} passed, ${errored.length} failed`;
+    let res = `${success.length} tests passed, ${errored.length} failed`;
     if (flaky.length) {
         res += `, ${flaky.length} flaky`;
     }

--- a/src/runner.js
+++ b/src/runner.js
@@ -243,11 +243,11 @@ async function sequential_run(config, state) {
  * @param {Task} task
  */
 function update_results(config, state, task) {
-    const { resultById, flakyCounts } = state;
+    const { resultByTaskId, flakyCounts } = state;
     const testId = task.tc.id || task.tc.name;
     assert(testId);
 
-    const result = resultById.get(testId);
+    const result = resultByTaskId.get(testId);
     assert(result);
 
     let status = task.status;
@@ -460,11 +460,11 @@ async function parallel_run(config, state) {
 /**
  * @param {import('./config').Config} config
  * @param {TestCase[]} testCases
- * @param {RunnerState["resultById"]} resultById
+ * @param {RunnerState["resultByTaskId"]} resultByTaskId
  * @returns {Promise<Task[]>}
  * @private
  */
-async function testCases2tasks(config, testCases, resultById) {
+async function testCases2tasks(config, testCases, resultByTaskId) {
     const repeat = config.repeat || 1;
     assert(Number.isInteger(repeat), `Repeat configuration is not an integer: ${repeat}`);
 
@@ -496,7 +496,7 @@ async function testCases2tasks(config, testCases, resultById) {
             }
         }
 
-        resultById.set(task.id, {
+        resultByTaskId.set(task.id, {
             expectedToFail: task.expectedToFail,
             skipReason: task.skipReason,
             id: task.id,
@@ -534,7 +534,7 @@ async function testCases2tasks(config, testCases, resultById) {
  * @property {string} last_logged_status The last status string that was logged
  * to the console.
  * @property {Map<string, number>} flakyCounts Track flakyness run count of a test
- * @property {Map<string, import('./render').TestResult>} resultById
+ * @property {Map<string, import('./render').TestResult>} resultByTaskId
  */
 
 /**
@@ -558,13 +558,13 @@ async function run(config, testCases) {
     external_locking.prepare(config);
     const initData = config.beforeAllTests ? await config.beforeAllTests(config) : undefined;
 
-    const resultById = new Map();
-    const tasks = await testCases2tasks(config, testCases, resultById);
+    const resultByTaskId = new Map();
+    const tasks = await testCases2tasks(config, testCases, resultByTaskId);
     /** @type {RunnerState} */
     const state = {
         flakyCounts: new Map(),
         tasks,
-        resultById,
+        resultByTaskId,
         last_logged_status: ''
     };
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -237,6 +237,51 @@ async function sequential_run(config, state) {
 }
 
 /**
+ * Update test results
+ * @param {import('./config').Config} config
+ * @param {RunnerState} state
+ * @param {Task} task
+ */
+function update_results(config, state, task) {
+    const { resultById, flakyCounts } = state;
+    const testId = task.tc.id || task.tc.name;
+    assert(testId);
+
+    const result = resultById.get(testId);
+    assert(result);
+
+    let status = task.status;
+    if (config.repeatFlaky > 0 && status === 'success' || status === 'error') {
+        const runs = flakyCounts.get(testId) || 1;
+        if (runs > 1) {
+            if (runs < config.repeatFlaky && task.status !== 'success') {
+                status = 'todo';
+            } else if (task.status === 'success') {
+                status = 'flaky';
+            } else {
+                status = 'error';
+            }
+        }
+    }
+    result.status = status;
+
+    if (task.status === 'error' || task.status === 'success' || task.status === 'skipped') {
+        result.taskResults.push({
+            status: task.status,
+            duration: task.duration, // TODO,
+            error_stack: task.error ?
+                // Node's assert module modifies the Error's stack property and
+                // adds ansi color codes. These can only be disabled globally via
+                // an environment variable, but we want to keep colorized output
+                // for the cli. So we need to strip the ansi codes from the assert
+                // stack.
+                kolorist.stripColors(task.error.stack)
+                : null,
+        });
+    }
+}
+
+/**
  * @param {import('./config').Config} config
  * @param {RunnerState} state
  * @param {Task} task
@@ -269,6 +314,7 @@ async function run_one(config, state, task) {
         });
     }
 
+    update_results(config, state, task);
     output.status(config, state);
     return task;
 }
@@ -388,7 +434,7 @@ async function parallel_run(config, state) {
  */
 
 /**
- * @typedef {"success" | "running" | "error" | "todo"} TaskStatus
+ * @typedef {"success" | "running" | "error" | "todo" | "skipped"} TaskStatus
  */
 
 /**
@@ -406,10 +452,11 @@ async function parallel_run(config, state) {
 /**
  * @param {import('./config').Config} config
  * @param {TestCase[]} testCases
+ * @param {RunnerState["resultById"]} resultById
  * @returns {Promise<Task[]>}
  * @private
  */
-async function testCases2tasks(config, testCases) {
+async function testCases2tasks(config, testCases, resultById) {
     const repeat = config.repeat || 1;
     assert(Number.isInteger(repeat), `Repeat configuration is not an integer: ${repeat}`);
 
@@ -441,6 +488,17 @@ async function testCases2tasks(config, testCases) {
             }
         }
 
+        resultById.set(task.id, {
+            expectedToFail: task.expectedToFail,
+            skipReason: task.skipReason,
+            id: task.id,
+            status: task.status,
+            name: task.tc.name,
+            description: task.tc.description,
+            skipped: task.status === 'skipped',
+            taskResults: []
+        });
+
         locking.annotateTaskResources(config, task);
 
         if (skipReason || (repeat === 1)) {
@@ -468,6 +526,7 @@ async function testCases2tasks(config, testCases) {
  * @property {string} last_logged_status The last status string that was logged
  * to the console.
  * @property {Map<string, number>} flakyCounts Track flakyness run count of a test
+ * @property {Map<string, import('./render').TestResult>} resultById
  */
 
 /**
@@ -491,11 +550,13 @@ async function run(config, testCases) {
     external_locking.prepare(config);
     const initData = config.beforeAllTests ? await config.beforeAllTests(config) : undefined;
 
-    const tasks = await testCases2tasks(config, testCases);
+    const resultById = new Map();
+    const tasks = await testCases2tasks(config, testCases, resultById);
     /** @type {RunnerState} */
     const state = {
         flakyCounts: new Map(),
         tasks,
+        resultById,
         last_logged_status: ''
     };
 

--- a/tests/flaky_tests/error.js
+++ b/tests/flaky_tests/error.js
@@ -1,0 +1,8 @@
+async function run() {
+    throw new Error('fail');
+}
+
+module.exports = {
+    description: 'Test that fails',
+    run,
+};

--- a/tests/flaky_tests/flaky.js
+++ b/tests/flaky_tests/flaky.js
@@ -1,0 +1,11 @@
+let i = 0;
+async function run() {
+    if (i++ < 2) {
+        throw new Error('fail');
+    }
+}
+
+module.exports = {
+    description: 'Test that is flaky',
+    run,
+};

--- a/tests/flaky_tests/run
+++ b/tests/flaky_tests/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});

--- a/tests/flaky_tests/success.js
+++ b/tests/flaky_tests/success.js
@@ -1,0 +1,6 @@
+async function run() {}
+
+module.exports = {
+    description: 'Test that succeeds',
+    run,
+};

--- a/tests/selftest_flaky_detection.js
+++ b/tests/selftest_flaky_detection.js
@@ -6,12 +6,15 @@ const render = require('../src/render');
  * @param {import('../src/runner').TaskConfig} config
  */
 async function run(config) {
+    let output = [];
     const runnerConfig = {
         ...config,
-        logFunc: () => null,
+        colors: false,
+        logFunc: (_, message) => output.push(message),
         repeatFlaky: 3,
         quiet: true,
     };
+
 
     function createTests() {
         let i = 0;
@@ -69,13 +72,17 @@ async function run(config) {
 
     // Sequential run
     let tests = createTests();
+    output = [];
     let result = await runner.run({...runnerConfig, concurrency: 1}, tests);
     assertResult(result);
+    assert(output[output.length-1].includes('2 flaky (foo, bob)'), 'Summary did not include flaky tests');
 
     // Parallel run
     tests = createTests();
+    output = [];
     result = await runner.run({...runnerConfig, concurrency: 1}, tests);
     assertResult(result);
+    assert(output[output.length-1].includes('2 flaky (foo, bob)'), 'Summary did not include flaky tests');
 }
 
 module.exports = {

--- a/tests/selftest_flaky_result.js
+++ b/tests/selftest_flaky_result.js
@@ -1,0 +1,30 @@
+
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'flaky_tests', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-colors', '--no-screenshots', '--repeat-flaky', '3', '--ci'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    const summary = stderr.split('\n').filter(Boolean).slice(-3).map(s => s.trim());
+    assert.deepEqual(summary, [
+        '1 tests passed',
+        '1 failed (error)',
+        '1 flaky (flaky)'
+    ]);
+}
+
+module.exports = {
+    description: 'Test flaky result output',
+    run,
+};

--- a/tests/selftest_flaky_result.js
+++ b/tests/selftest_flaky_result.js
@@ -16,7 +16,26 @@ async function run() {
         );
     });
 
-    const summary = stderr.split('\n').filter(Boolean).slice(-3).map(s => s.trim());
+    const lines = stderr.split('\n').filter(Boolean);
+    const status = lines.slice(0, -3);
+
+    // Check that failure count is consistent
+    let failed = 0;
+    for (const line of status) {
+        const m = /(\d+)\sfailed/g.exec(line);
+        if (m) {
+            const actual_failed = +m[1];
+            if (failed > 0) {
+                assert(
+                    failed <= actual_failed,
+                    `Failed test count decreased in status output.\nCurrent: ${actual_failed}\nPrevious: ${failed}`
+                );
+            }
+            failed = actual_failed;
+        }
+    }
+
+    const summary = lines.slice(-3).map(s => s.trim());
     assert.deepEqual(summary, [
         '1 tests passed',
         '1 failed (error)',


### PR DESCRIPTION
With flakyness detection in place we're now in the situation where a `task` result doesn't map 1:1 to a test result anymore. Instead X tasks are grouped together to determine if we have a flaky test or not. For a setting of `--repeat-flaky` the result should be reported as:

```txt
1 flaky (foo)
```

instead of:

```txt
2 failed (foo, foo[1])
1 success (foo[2])
```

To do that the status reporting is based on tests results instead of tasks. Most of the building blocks were already in place for PDF and markdown generation, but the `runner` did it's own status calculations. This PR reworks it, so that the runner builds up test results incrementally.

So the runner status is composed of the following numbers:

```txt
10/100 done, 1 failed, 1 expected to fail, 3 flaky
^     ^          ^           ^                 ^
|     |        tests       tests             tests
tasks tasks
```

The changeset is admittedly larger that I'd planned but most of it is caused by moving the result extracting code out of `render.js`.

_FYI: There is draft PR which adds support for using both `--repeat` and `--repeat-flaky` at the same time. But the changes would be too large to be included here. See #232 ._