### PR TITLE
Fix flakyness detection not working with --repeat

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -32,11 +32,11 @@ function clean(config) {
 function status(config, state) {
     if (config.quiet) return;
     assert(state.tasks);
-    assert(state.resultByTaskId);
+    assert(state.resultByTaskName);
 
     last_state = state;
 
-    const testResults = Array.from(state.resultByTaskId.values());
+    const testResults = Array.from(state.resultByTaskName.values());
     const {errored, expectedToFail, skipped} = getResults(config, testResults);
     const {tasks} = state;
 
@@ -112,7 +112,7 @@ function formatDuration(config, duration) {
  */
 function detailedStatus(config, state) {
     const {tasks} = state;
-    const testResults = Array.from(state.resultByTaskId.values());
+    const testResults = Array.from(state.resultByTaskName.values());
     const {skipped} = getResults(config, testResults);
 
     const done = tasks.filter(t => t.status === 'success' || t.status === 'error');
@@ -218,7 +218,7 @@ function finish(config, state) {
     if (tasks.length === 0 && config.filter) {
         msg += `No test case found with filter: ${config.filter}\n`;
     }
-    const testResults = Array.from(state.resultByTaskId.values());
+    const testResults = Array.from(state.resultByTaskName.values());
     const results = getResults(config, testResults);
     msg += resultSummary(config, results);
 

--- a/src/render.js
+++ b/src/render.js
@@ -61,7 +61,7 @@ function craftResults(config, test_info) {
     const {test_start, test_end, state, ...moreInfo} = test_info;
 
     /** @type {TestResult[]} */
-    const tests = Array.from(state.resultByTaskId.values());
+    const tests = Array.from(state.resultByTaskName.values());
 
     // Order tests by severity
     tests.sort((testA, testB) => {

--- a/src/runner.js
+++ b/src/runner.js
@@ -244,15 +244,15 @@ async function sequential_run(config, state) {
  */
 function update_results(config, state, task) {
     const { resultByTaskId, flakyCounts } = state;
-    const testId = task.tc.id || task.tc.name;
-    assert(testId);
+    const {name} = task;
+    assert(name);
 
-    const result = resultByTaskId.get(testId);
+    const result = resultByTaskId.get(name);
     assert(result);
 
     let status = task.status;
     if (config.repeatFlaky > 0 && status === 'success' || status === 'error') {
-        const runs = flakyCounts.get(testId) || 1;
+        const runs = flakyCounts.get(name) || 1;
         // Not flaky if the first run was successful
         if (!(runs === 1 && task.status === 'success')) {
             // If task is failing, but we haven't reached the limit, then
@@ -300,9 +300,8 @@ async function run_one(config, state, task) {
 
     if (task.status === 'skipped') return task;
 
-    const tcName = task.tc.name;
-    const count = state.flakyCounts.get(tcName) || 0;
-    state.flakyCounts.set(tcName, count + 1);
+    const count = state.flakyCounts.get(task.name) || 0;
+    state.flakyCounts.set(task.name, count + 1);
 
     task.status = 'running';
     task.start = performance.now();
@@ -312,13 +311,15 @@ async function run_one(config, state, task) {
 
     const repeat = config.repeat || 1;
     if (count < config.repeatFlaky - 1 && task.status === 'error' && !task.expectedToFail) {
-        output.logVerbose(config, `Retrying task for flaky detection. Retry count: ${count + 1} (${task.id})`);
+        output.logVerbose(config, `[runner] Retrying task for flaky detection. Retry count: ${count + 1} (${task.id})`);
+        const tcName = task.tc.name;
         state.tasks.push({
             ...task,
             status: 'todo',
             breadcrumb: null,
             id: `${tcName}_${repeat + count}`,
-            name: `${tcName}[${repeat + count}]`,
+            // Keep task.name the same, so that we can group results together
+            name: task.name
         });
     }
 
@@ -448,7 +449,7 @@ async function parallel_run(config, state) {
 /**
  * @typedef {Object} Task
  * @property {string} id
- * @property {string} name
+ * @property {string} name Name of the task. Note that this is used to group results of flaky detection.
  * @property {TestCase} tc
  * @property {TaskStatus} status
  * @property {number} start
@@ -456,6 +457,23 @@ async function parallel_run(config, state) {
  * @property {boolean} [skipReason]
  * @property {boolean | ((config: import('./config').Config) => boolean)} [expectedToFail]
  */
+
+/**
+ * @param {RunnerState["resultByTaskId"]} resultByTaskId
+ * @param {Task} task
+ */
+function initTaskResult(resultByTaskId, task) {
+    resultByTaskId.set(task.name, {
+        expectedToFail: task.expectedToFail,
+        skipReason: task.skipReason,
+        id: task.id,
+        status: task.status,
+        name: task.name,
+        description: task.tc.description,
+        skipped: task.status === 'skipped',
+        taskResults: []
+    });
+}
 
 /**
  * @param {import('./config').Config} config
@@ -496,31 +514,23 @@ async function testCases2tasks(config, testCases, resultByTaskId) {
             }
         }
 
-        resultByTaskId.set(task.id, {
-            expectedToFail: task.expectedToFail,
-            skipReason: task.skipReason,
-            id: task.id,
-            status: task.status,
-            name: task.tc.name,
-            description: task.tc.description,
-            skipped: task.status === 'skipped',
-            taskResults: []
-        });
-
         locking.annotateTaskResources(config, task);
 
         if (skipReason || (repeat === 1)) {
             tasks[position] = task;
+            initTaskResult(resultByTaskId, task);
             return;
         }
 
         for (let runId = 0;runId < repeat;runId++) {
-            tasks[runId * testCases.length + position] = {
+            const repeatTask = {
                 ...task,
                 breadcrumb: null,
                 id: `${tc.name}_${runId}`,
                 name: `${tc.name}[${runId}]`,
             };
+            tasks[runId * testCases.length + position] = repeatTask;
+            initTaskResult(resultByTaskId, repeatTask);
         }
     }));
     return tasks.filter(t => t);

--- a/tests/flaky_tests/flaky.js
+++ b/tests/flaky_tests/flaky.js
@@ -1,11 +1,16 @@
-let i = 0;
-async function run() {
-    if (i++ < 2) {
+const state = new Map();
+async function run(config) {
+    let i = state.has(config._taskName) ? state.get(config._taskName) : -1;
+    i++;
+    if (i === 0 || (i + 1) % 3 !== 0) {
+        state.set(config._taskName, i);
         throw new Error('fail');
+    } else {
+        state.set(config._taskName, i);
     }
 }
 
 module.exports = {
-    description: 'Test that is flaky',
+    description: 'Test that is flaky and fails every 3rd run in the same flaky group',
     run,
 };

--- a/tests/selftest_flaky_result_repeat.js
+++ b/tests/selftest_flaky_result_repeat.js
@@ -1,0 +1,49 @@
+
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'flaky_tests', 'run');
+    const {stderr} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-colors', '--no-screenshots',  '--repeat', '3', '--repeat-flaky', '3', '--quiet'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    const lines = stderr.split('\n').filter(Boolean);
+    const status = lines.slice(0, -3);
+
+    // Check that failure count is consistent
+    let failed = 0;
+    for (const line of status) {
+        const m = /(\d+)\sfailed/g.exec(line);
+        if (m) {
+            const actual_failed = +m[1];
+            if (failed > 0) {
+                assert(
+                    failed <= actual_failed,
+                    `Failed test count decreased in status output.\nCurrent: ${actual_failed}\nPrevious: ${failed}`
+                );
+            }
+            failed = actual_failed;
+        }
+    }
+
+    const summary = lines.slice(-3).map(s => s.trim());
+    assert.deepEqual(summary, [
+        '3 tests passed',
+        '3 failed (error[0], error[1], error[2])',
+        '3 flaky (flaky[0], flaky[1], flaky[2])'
+    ]);
+}
+
+module.exports = {
+    description: 'Test flaky result output when --repeat is enabled',
+    run,
+};


### PR DESCRIPTION
This PR ensures that `--repeat` works together with `--repeat-flaky`. We initially grouped tests by `task.id` but that doesn't because `task.id` is meant to be unique. Instead we group on `task.name` which is much more reliable and makes the `--repeat` case work without much work. Each repeated test is treated as a unique test case internally, so we can correctly group related flaky detection runs. 