### PR TITLE
Fix screenshots missing in results

### DIFF
--- a/src/render.js
+++ b/src/render.js
@@ -1,4 +1,5 @@
 const fs = require('fs');
+const path = require('path');
 const {promisify} = require('util');
 const {html2pdf} = require('./browser_utils');
 const {timezoneOffsetString} = require('./utils');
@@ -98,24 +99,28 @@ async function doRender(config, results) {
     if (config.json) {
         output.logVerbose('Rendering to JSON ...');
         const json = JSON.stringify(results, undefined, 2) + '\n';
-        await promisify(fs.writeFile)(config.json_file, json, {encoding: 'utf-8'});
+        const fileName = path.join(config._rootDir, config.json_file);
+        await promisify(fs.writeFile)(fileName, json, {encoding: 'utf-8'});
     }
 
     if (config.markdown) {
         output.logVerbose('Rendering to Markdown ...');
         const md = markdown(results);
-        await promisify(fs.writeFile)(config.markdown_file, md, {encoding: 'utf-8'});
+        const fileName = path.join(config._rootDir, config.markdown_file);
+        await promisify(fs.writeFile)(fileName, md, {encoding: 'utf-8'});
     }
 
     if (config.html) {
         output.logVerbose('Rendering to HTML ...');
         const html_code = html(results);
-        await promisify(fs.writeFile)(config.html_file, html_code, {encoding: 'utf-8'});
+        const fileName = path.join(config._rootDir, config.html_file);
+        await promisify(fs.writeFile)(fileName, html_code, {encoding: 'utf-8'});
     }
 
     if (config.pdf) {
         output.logVerbose('Rendering to PDF ...');
-        await pdf(config, config.pdf_file, results);
+        const fileName = path.join(config._rootDir, config.pdf_file);
+        await pdf(config, fileName, results);
     }
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -287,6 +287,7 @@ function update_results(config, state, task) {
                 // stack.
                 kolorist.stripColors(task.error.stack)
                 : null,
+            error_screenshots: task.error_screenshots,
         });
     }
 }
@@ -459,6 +460,7 @@ async function parallel_run(config, state) {
  * @property {number} start
  * @property {Error | null} breadcrumb
  * @property {boolean} [skipReason]
+ * @property {Buffer[]} error_screenshots
  * @property {boolean | ((config: import('./config').Config) => boolean)} [expectedToFail]
  */
 

--- a/tests/screenshot_tests/error.js
+++ b/tests/screenshot_tests/error.js
@@ -1,0 +1,12 @@
+const {newPage} = require('../../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    page.setContent('<h1>Hello world</h1>');
+    await page.waitForSelector('h2',{timeout: 500});
+}
+
+module.exports = {
+    description: 'Force screenshot generation',
+    run,
+};

--- a/tests/screenshot_tests/run
+++ b/tests/screenshot_tests/run
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+    testsDir: __dirname,
+});

--- a/tests/selftest_result.js
+++ b/tests/selftest_result.js
@@ -1,0 +1,50 @@
+const assert = require('assert').strict;
+const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
+const rimrafCb = require('rimraf');
+const {promisify} = require('util');
+
+const rimraf = promisify(rimrafCb);
+
+async function run() {
+    const fixture = path.join(__dirname, 'screenshot_tests');
+
+    const html_file = path.join(fixture, 'results.html');
+    const md_file = path.join(fixture, 'results.md');
+    const json_file = path.join(fixture, 'results.json');
+    const screenshot_dir = path.join(fixture, 'screenshot_directory');
+
+    await rimraf(html_file);
+    await rimraf(md_file);
+    await rimraf(json_file);
+    await rimraf(screenshot_dir);
+
+    await new Promise((resolve, reject) => {
+        child_process.execFile(
+            path.join(fixture, 'run'),
+            ['--exit-zero', '--html', '--json', '--markdown', '--pdf'],
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    const html = await fs.promises.readFile(html_file, 'utf-8');
+    assert(
+        /<img src="data:image\/png;base64/.test(html),
+        'Could not find <img src="..." /> in html'
+    );
+
+    // Markdown file doesn't contain screenshot. Just make sure that it exists.
+    await fs.promises.readFile(md_file, 'utf-8');
+
+    const json = JSON.parse(await fs.promises.readFile(json_file, 'utf-8'));
+    assert.equal(json.tests[0].taskResults[0].error_screenshots.length, 1);
+}
+
+module.exports = {
+    description: 'Check that results are generated and contain screenshots',
+    run,
+};


### PR DESCRIPTION
This PR fixes an error where screenshots weren't included in the result files. They were all present in the screenshots directory, but #231 had a regression where the screenshot path was not included in the result objects.