### PR TITLE
Fix tests with inline expectedToFail not marked as such

### DIFF
--- a/src/output.js
+++ b/src/output.js
@@ -594,7 +594,7 @@ async function formatError(config, err) {
 function shouldShowError(config, task) {
     return (
         !(config.ignore_errors && (new RegExp(config.ignore_errors)).test(task.error.stack)) &&
-        (config.expect_nothing || !task.expectedToFail));
+        (config.expect_nothing || !task.expectedToFail || task.expectedToFail && task.status === 'success'));
 }
 
 /**

--- a/src/runner.js
+++ b/src/runner.js
@@ -109,8 +109,14 @@ async function run_task(config, task) {
         task.duration = performance.now() - task.start;
         task.error = e;
         task.breadcrumb = task_config._breadcrumb;
+        task.status = 'error';
+
+        // Inline expectedToFail() calls
         if (e.pentf_expectedToFail) {
             task.expectedToFail = e.pentf_expectedToFail;
+        } else if (e.pentf_expectedToSucceed) {
+            task.expectedToFail = e.pentf_expectedToSucceed;
+            task.status = 'success';
         }
 
         if (config.take_screenshots) {
@@ -186,8 +192,6 @@ async function run_task(config, task) {
 
         output.logVerbose(
             config, `[task] Error teardown done for ${task._runner_task_id} (${task.name})`);
-
-        task.status = 'error';
 
         if (config.fail_fast) {
             process.exit(3);
@@ -289,6 +293,11 @@ function update_results(config, state, task) {
                 : null,
             error_screenshots: task.error_screenshots,
         });
+    }
+
+    // Update in case inline expectedToFail was used
+    if (!result.expectedToFail && task.expectedToFail) {
+        result.expectedToFail = task.expectedToFail;
     }
 }
 

--- a/tests/expectedToFail_section.js
+++ b/tests/expectedToFail_section.js
@@ -47,12 +47,16 @@ async function run() {
         },
     }];
 
-    await runner.run(runnerConfig, testCases);
+    const result = await runner.run(runnerConfig, testCases);
     assert(! output.some(o => o.includes('test case normal_ok')));
     assert(! output.some(o => o.includes('FAILED test case section_fail')));
     assert(output.some(o => o.includes('PASSED test case section_ok')));
     assert(output.some(o => o.includes('FAILED test case section_expectNothing_fail')));
     assert(! output.some(o => o.includes('test case section_expectNothing_ok')));
+
+    const groups = result.state.resultByTaskGroup;
+    assert(groups.get('section_fail').expectedToFail, 'expectedToFail not present on result for "section_fail"');
+    assert(groups.get('section_ok').expectedToFail, 'expectedToFail not present on result for "section_ok"');
 
     output = [];
     runnerConfig.expect_nothing = true;


### PR DESCRIPTION
This PR fixes tests which called `expectedToFail()` during their run not being marked as `expectedToFail`.

```js
async function run(config) {
  await expectedToFail(config, "should not work", () => {
    throw new Error("fail");
  });
}

module.exports = {
  run,
  // NO expectedToFail here
}
```