### PR TITLE
Fix typescript not finding module types

### DIFF
--- a/package.json
+++ b/package.json
@@ -129,7 +129,7 @@
   "scripts": {
     "test": "./run",
     "lint": "eslint . run",
-    "types": "tsc",
+    "types": "tsc && cp dist/types/* .",
     "build": "babel --out-dir dist/ --out-file-extension .mjs src/*.js",
     "clean": "rimraf doc dist",
     "prepublishOnly": "npm run clean && npm run types && npm run build"


### PR DESCRIPTION
Turns out that TypeScript doesn't support resolving export maps just yet. It resolves files by traversing the directories directly and only does exceptions when it encounters a `package.json` file somewhere. Therefore the easiest solution to get types for sub-imports working again is to just duplicate our typing files.