### PR TITLE
Support full config object in pentf.main

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -214,7 +214,7 @@ function parseArgs(options, raw_args) {
     });
     selection_group.addArgument(['--tests-glob'], {
         dest: 'testsGlob',
-        defaultValue: undefined,
+        defaultValue: '*.{js,cjs,mjs}',
         help: 'Glob pattern to use when searching test files',
     });
 
@@ -386,7 +386,19 @@ function parseArgs(options, raw_args) {
         help: 'Display the locking client ID we would use if we would lock something now',
     });
 
+    // Overwrite config object passed to `pentf.main()` with command line
+    // arguments. But only overwrite any existing config properties passed
+    // to `pentf.main()` if they were actually set via the cli. If the
+    // property doesn't exist in the existing config and we didn't specify
+    // it as a cli argument, we'll use the default value.
     const args = parser.parseArgs(raw_args);
+    for (const k in parser._actions) {
+        const flag = parser._actions[k];
+        if (flag.dest in options && args[flag.dest] === flag.defaultValue) {
+            args[flag.dest] = options[flag.dest];
+        }
+    }
+
     if (args.json_file !== DEFAULT_JSON_NAME && !args.json) {
         console.log('Warning: --json-file given, but not -j/--json. Will NOT write JSON.'); // eslint-disable-line no-console
     }

--- a/src/loader.js
+++ b/src/loader.js
@@ -187,10 +187,10 @@ function loadSuite(suiteName, builder) {
 /**
  * @param {*} args
  * @param {string} testsDir
- * @param {string} [globPattern]
+ * @param {string} globPattern
  * @private
  */
-async function loadTests(args, testsDir, globPattern = '*.{js,cjs,mjs}') {
+async function loadTests(args, testsDir, globPattern) {
     const testFiles = await promisify(glob.glob)(globPattern, {cwd: testsDir});
     let tests = testFiles.map(n => ({
         path: n,

--- a/tests/parse_args.js
+++ b/tests/parse_args.js
@@ -3,6 +3,29 @@ const {parseArgs} = require('../src/config');
 
 async function run() {
     assert.equal(parseArgs({}, [ '--ci']).ci, true);
+
+    // Only pentf.main
+    assert.equal(
+        parseArgs(
+            {
+                testsGlob: '*.foo.js',
+            },
+            []
+        ).testsGlob,
+        '*.foo.js'
+    );
+    // Only cli
+    assert.equal(parseArgs({}, ['--tests-glob', '*.bar.js']).testsGlob, '*.bar.js');
+    // Both pentf.main + cli. Cli should overwrite properties
+    assert.equal(
+        parseArgs(
+            {
+                testsGlob: '*.foo.js',
+            },
+            ['--tests-glob', '*.bar.js']
+        ).testsGlob,
+        '*.bar.js'
+    );
 }
 
 module.exports = {

--- a/tests/selftest_loader.js
+++ b/tests/selftest_loader.js
@@ -4,16 +4,25 @@ const {loadTests} = require('../src/loader');
 
 async function run(config) {
     assert.deepStrictEqual(
-        (await loadTests({filter: 'selftest_lo[ao]der'}, config._testsDir)).map(t => t.name),
-        ['selftest_loader'],
+        (await loadTests({filter: 'selftest_lo[ao]der'}, config._testsDir, '*.js')).map(
+            t => t.name
+        ),
+        ['selftest_loader']
     );
 
     // random string: he5Eih1ohhhhhhai8sho
-    const byBody = await loadTests({
-        filter: 'selftest_[a-l]',
-        filter_body: 'he5Eih1oh+ai8sho',
-    }, config._testsDir);
-    assert.deepStrictEqual(byBody.map(t => t.name), ['selftest_loader']);
+    const byBody = await loadTests(
+        {
+            filter: 'selftest_[a-l]',
+            filter_body: 'he5Eih1oh+ai8sho',
+        },
+        config._testsDir,
+        '*.js'
+    );
+    assert.deepStrictEqual(
+        byBody.map(t => t.name),
+        ['selftest_loader']
+    );
 }
 
 module.exports = {


### PR DESCRIPTION
This PR allows any config property to be passed to `pentf.main()`, not just a few limited ones like before. Any actively passed cli flags will take precedence over properties passed via `pentf.main()`.