### PR TITLE
Guard against "Execution Context destroyed" error

### DIFF
--- a/tests/selftest_navigation_context_destroyed.js
+++ b/tests/selftest_navigation_context_destroyed.js
@@ -1,20 +1,80 @@
-const {clickXPath, closePage, newPage} = require('../src/browser_utils');
+const {
+    clickXPath,
+    newPage,
+    waitForVisible,
+    waitForText,
+    waitForTestId,
+    assertNotXPath,
+    clickSelector,
+    assertNotSelector,
+    clickText,
+    clickNestedText,
+    clickTestId,
+    assertNotTestId,
+} = require('../src/browser_utils');
+
+async function reset(page) {
+    await page.goto('about:blank');
+    const html = `
+        <html>
+            <script>
+                setTimeout(() => location.href = 'https://example.com/', 1000);
+            </script>
+            <body>original</body>
+        </html>
+    `;
+    await page.setContent(html);
+}
 
 async function run(config) {
-    const page = await newPage(config);
+    const page = await newPage({...config, default_timeout: 3000});
 
-    await page.setContent(`<html><script>
-        setTimeout(() => location.href = 'https://google.com/', 1000);
-    </script>
-    <body>original</body></html>`);
-    await clickXPath(page, '//button');
+    await reset(page);
+    await clickXPath(page, '//h1');
 
-    await closePage(page);
+    await reset(page);
+    await waitForVisible(page, 'h1');
+
+    await reset(page);
+    await waitForText(page, 'Example');
+
+    await reset(page);
+    await page.evaluate(() => {
+        const div = document.createElement('div');
+        div.setAttribute('data-testid', 'foo');
+        document.body.appendChild(div);
+    });
+    await waitForTestId(page, 'foo');
+
+    await reset(page);
+    await assertNotXPath(page, '//foo');
+
+    await reset(page);
+    await clickSelector(page, 'h1');
+
+    await reset(page);
+    await assertNotSelector(page, 'h10');
+
+    await reset(page);
+    await clickText(page, 'More information');
+
+    await reset(page);
+    await clickNestedText(page, 'Example');
+
+    await reset(page);
+    await page.evaluate(() => {
+        const div = document.createElement('div');
+        div.setAttribute('data-testid', 'foo');
+        document.body.appendChild(div);
+    });
+    await clickTestId(page, 'foo');
+
+    await reset(page);
+    await assertNotTestId(page, 'foo');
 }
 
 module.exports = {
     description: 'Test clickXPath while navigating',
     resources: [],
     run,
-    expectedToFail: 'https://github.com/boxine/pentf/issues/127',
 };


### PR DESCRIPTION
Whenever a navigation occurs and we're waiting for an element, `puppeteer` will throw an `"Execution context was destroyed error"`. The official docs suggest manually waiting on navigation events:

```js
await Promise.all([
  await page.waitForNavigation(),
  await waitForSelector('foo')
]);
```

This is annoying to write and has lead to flaky tests for us. Based on that a better solution is to catch these errors internally and simply retry our matcher functions. The above snippet becomes a lot shorter with these changes:

```js
await waitForSelector('foo');
```

Fixes #127 .