### PR TITLE
Fix broken module loading in esm mode

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -35,7 +35,9 @@ async function importFile(file) {
     // Only use import() for JavaScript files. Patching module
     // resolution of import() calls is still very experimental, so
     // tools like `ts-node´ need to keep using `require` calls.
-    if (/\.[cm]?js$/.test(file) && canUseImport) {
+    // Note that we still need to forward loading from `node_modules`
+    // to `import()` regardless.
+    if ((/\.[cm]?js$/.test(file) || !file.includes('.')) && canUseImport) {
         // Use dynamic import statement to be able to load both native esm
         // and commonjs modules.
 


### PR DESCRIPTION
Turns out that the regex to allow non-js files to be passed through to `require` for `ts-node` and other compilers was a bit too greedy. Normal module paths like `importFile('puppeteer')` **must not** be passed to `require` when one of the parent files is in ESM mode.

Note that we cannot use that `path.isAbsolute` method to check if we're dealing with a relative path, as we get a mix of urls and paths in ESM. We can pretty certain that a module path/url has no dot in it, so we should be fine.