### PR TITLE
Add more verbose logs

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -103,7 +103,10 @@ async function real_main(options={}) {
 
         // Run tests
         const test_info = await runner.run(config, test_cases);
-        if (!test_info) return;
+        if (!test_info) {
+            logVerbose(config, '[runner] No run information returned by runner');
+            return;
+        }
 
         results = render.craftResults(config, test_info);
     }

--- a/src/render.js
+++ b/src/render.js
@@ -60,6 +60,7 @@ function getTestOrder(config, result) {
  * @param {import('./runner').RunnerResult} test_info
  */
 function craftResults(config, test_info) {
+    output.logVerbose(config, '[results] crafting results...');
     const {test_start, test_end, state, ...moreInfo} = test_info;
 
     /** @type {TestResult[]} */
@@ -96,6 +97,8 @@ function craftResults(config, test_info) {
 }
 
 async function doRender(config, results) {
+    output.logVerbose(config, '[results] Render results');
+
     if (config.json) {
         output.logVerbose('Rendering to JSON ...');
         const json = JSON.stringify(results, undefined, 2) + '\n';

--- a/src/runner.js
+++ b/src/runner.js
@@ -705,7 +705,7 @@ async function run(config, testCases) {
     const now = new Date();
     const test_end = now.getTime();
 
-    output.logVerbose(config, `Test ended at ${utils.localIso8601(now)}, crafting results`);
+    output.logVerbose(config, `Test run ended at ${utils.localIso8601(now)}`);
     const testsVersion = await timeoutPromise(
         config, version.testsVersion(config), {message: 'version determination', warning: true});
     const pentfVersion = version.pentfVersion();


### PR DESCRIPTION
We encountered a few runs where no PDF file was generated. Add more log statements to see where pentf aborts.