### PR TITLE
Fix incorrect log file location

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -95,7 +95,8 @@ async function real_main(options={}) {
         results = JSON.parse(json_input);
     } else {
         if (config.log_file && !config.log_file_stream) {
-            const stream = fs.createWriteStream(config.log_file, { flags: 'w' });
+            const fileName = path.join(config._rootDir, config.log_file);
+            const stream = fs.createWriteStream(fileName, { flags: 'w' });
             const time = localIso8601();
             stream.write(`${time} Start runner\n`);
             config.log_file_stream = stream;

--- a/tests/selftest_log_file.js
+++ b/tests/selftest_log_file.js
@@ -21,7 +21,7 @@ async function run() {
     await new Promise((resolve, reject) => {
         child_process.execFile(
             sub_run,
-            ['--exit-zero', '--no-screenshots', '--log-file', logFile],
+            ['--exit-zero', '--no-screenshots', '--log-file', 'output.log'],
             (err, stdout, stderr) => {
                 if (err) reject(err);
                 else resolve({stdout, stderr});


### PR DESCRIPTION
Turns out that the log file was always written to the directory from where the process was launched, not where the sh script actually resides.