### PR TITLE
Add support for --config FILE flag

### DIFF
--- a/tests/config_file/pentf.config.js
+++ b/tests/config_file/pentf.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+    foo: true,
+};

--- a/tests/config_file/pentf.foo.config.js
+++ b/tests/config_file/pentf.foo.config.js
@@ -1,0 +1,5 @@
+module.exports = env => {
+    return {
+        foo: env,
+    };
+};

--- a/tests/selftest_config_file.js
+++ b/tests/selftest_config_file.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const {readConfig} = require('../src/config');
+
+async function run() {
+    const dir = path.join(__dirname, 'config_file');
+    const config = await readConfig(
+        { rootDir: dir },
+        { config_file: 'pentf.config.js' }
+    );
+
+    assert(config.foo);
+
+    // Check that we bail out of assertion on the root level
+    const config2 = await readConfig(
+        { rootDir: dir },
+        { config_file: 'pentf.foo.config.js', env: 'foo' }
+    );
+    assert.equal(config2.foo, 'foo');
+}
+
+module.exports = {
+    description: 'Support loading "--config FILE" configuration file (pentf.config.js)',
+    run,
+};


### PR DESCRIPTION
Most JavaScript tools support `[toolname].config.js` as a config file. These include, but are not limited to `babel.config.js`, `jest.config.js` and many others. The it's implemented is that it's loaded before the environment specific files, so that those can overwrite what's in `pentf.config.js`.

Based on #254 . Marking as a draft until that PR is merged.