### PR TITLE
Switch to always use native fs-Promise API

### DIFF
--- a/src/net_utils.js
+++ b/src/net_utils.js
@@ -4,10 +4,10 @@ const https = require('https');
 const node_fetch = require('node-fetch');
 const tough = require('tough-cookie');
 const {URL} = require('url');
+const fs = require('fs');
 
 const {makeCurlCommand} = require('./curl_command');
 const output = require('./output');
-const {readFile} = require('./utils');
 
 /**
  * fetch a URL.
@@ -159,8 +159,8 @@ async function setupTLSClientAuth(fetchOptions, keyFilename, certFilename, rejec
         rejectUnauthorized,
         keepAlive: true,
     };
-    agentOptions.key = await readFile(keyFilename, 'binary');
-    agentOptions.cert = await readFile(certFilename, 'binary');
+    agentOptions.key = await fs.promises.readFile(keyFilename, 'binary');
+    agentOptions.cert = await fs.promises.readFile(certFilename, 'binary');
     fetchOptions.agent = new https.Agent(agentOptions);
     if (!fetchOptions.curl_extra_options) {
         fetchOptions.curl_extra_options = [];

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,5 +1,4 @@
 const assert = require('assert').strict;
-const fs = require('fs');
 
 function makeEmailAddress(config, suffix) {
     assert(config.email, 'Missing `email` key in pentf configuration');
@@ -20,14 +19,6 @@ function makeRandomEmail(config, prefix=undefined) {
         prefix = config._testName || '';
     }
     return makeEmailAddress(config, prefix + Math.random().toString(36).slice(2));
-}
-
-async function readFile(fileName, type) {
-    return new Promise((resolve, reject) => {
-        fs.readFile(fileName, type, (err, data) => {
-            err ? reject(err) : resolve(data);
-        });
-    });
 }
 
 /**
@@ -231,7 +222,6 @@ module.exports = {
     randomHex,
     randomHexstring,
     range,
-    readFile,
     regexEscape,
     remove,
     retry,


### PR DESCRIPTION
Node has a native promisified version of the `fs` module, so there is no need to create our own version.