### PR TITLE
Remove config._testsDir

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,9 +1,7 @@
 #!/usr/bin/env node
 const pentf = require('../src/index.js');
 
-const cwd = process.cwd();
 pentf.main({
     description: 'pentf - Parallel End-To-End Test Framework',
-    rootDir: cwd,
-    testsDir: cwd,
+    rootDir: process.cwd(),
 });

--- a/run
+++ b/run
@@ -6,6 +6,7 @@ const lockserver = require('./lockserver/lockserver');
 
 pentf.main({
     rootDir: __dirname, // Mandatory
+    testsGlob: 'tests/*.{js,mjs,cjs}',
     // All further properties are optional
     beforeAllTests: lockserver.beforeAllTests,
     afterAllTests: lockserver.afterAllTests,

--- a/src/config.js
+++ b/src/config.js
@@ -510,11 +510,11 @@ async function findPackageJson(dir) {
 async function readConfig(options, args) {
     const {configDir} = options;
 
-    let config = {};
-    const rootDir = options.rootDir || process.cwd();
+    let config = args;
+    config.rootDir = options.rootDir || process.cwd();
 
     // Add support for `pentf` configuration key in `package.json`.
-    const pkgJsonPath = await findPackageJson(rootDir);
+    const pkgJsonPath = await findPackageJson(config.rootDir);
     if (pkgJsonPath !== null) {
         const pkgJson = JSON.parse(await fs.promises.readFile(pkgJsonPath));
         config = pkgJson.pentf || config;
@@ -522,7 +522,7 @@ async function readConfig(options, args) {
 
     // "pentf.config.js" configuration file
     if (args.config_file) {
-        const configPath = path.join(rootDir, args.config_file);
+        const configPath = path.join(config.rootDir, args.config_file);
         if (await promisify(fs.exists)(configPath)) {
             const res = await importFile(configPath);
             const data = typeof res === 'function' ? res(args.env) : res;

--- a/src/loader.js
+++ b/src/loader.js
@@ -210,20 +210,19 @@ async function applyTestFilters(config, tests) {
 }
 
 /**
- * @param {*} args
- * @param {string} testsDir
+ * @param {import('./config').Config} config
  * @param {string} globPattern
  * @returns {Promise<import('./runner').TestCase[]>}
  * @private
  */
-async function loadTests(args, testsDir, globPattern) {
-    const testFiles = await promisify(glob.glob)(globPattern, {cwd: testsDir, absolute: true});
+async function loadTests(config, globPattern) {
+    const testFiles = await promisify(glob.glob)(globPattern, {cwd: config.rootDir, absolute: true});
     let tests = testFiles.map(n => ({
         fileName: n,
         name: path.basename(n, path.extname(n)),
     }));
 
-    tests = await applyTestFilters(args, tests);
+    tests = await applyTestFilters(config, tests);
 
     const testCases = [];
     await Promise.all(

--- a/src/main.js
+++ b/src/main.js
@@ -50,7 +50,6 @@ async function runTests(config, test_cases) {
  * @property {string} [description] program description in the --help output
  * @property {string} [rootDir] Root directory (assume tests/ contains tests,
  * config/ if exists contains config)
- * @property {string} [testsDir] Test directory
  * @property {string} [configDir] Configuration directory. false disables
  * configuration.
  */
@@ -60,9 +59,6 @@ async function runTests(config, test_cases) {
  */
 async function real_main(options={}) {
     if (options.rootDir) {
-        if (! options.testsDir) {
-            options.testsDir = path.join(options.rootDir, 'tests');
-        }
         if (! options.configDir) {
             const autoConfigDir = path.join(options.rootDir, 'config');
             if (fs.existsSync(autoConfigDir)) {
@@ -74,8 +70,8 @@ async function real_main(options={}) {
 
     const args = parseArgs(options, process.argv.slice(2));
     const config = await readConfig(options, args);
-    if (options.defaultConfig) {
-        options.defaultConfig(config);
+    if (config.defaultConfig) {
+        config.defaultConfig(config);
     }
 
     if (!config.colors) {
@@ -83,11 +79,7 @@ async function real_main(options={}) {
         process.env.NODE_DISABLE_COLORS = 'true';
     }
 
-    const globPath = config.testsGlob || options.testsGlob;
-    const test_cases = await loadTests(args, options.testsDir, globPath);
-    config._testsDir = options.testsDir;
-    if (options.rootDir) config._rootDir = options.rootDir;
-    if (options.configDir) config._configDir = options.configDir;
+    const test_cases = await loadTests(config, config.testsGlob);
 
     if (args.print_version) {
         console.log(await testsVersion(config));

--- a/src/output.js
+++ b/src/output.js
@@ -549,7 +549,7 @@ async function formatError(config, err) {
                 frame.fileName = frame.fileName.replace(/^(file)?:\/\//, '');
 
                 // Only show frame for errors in the user's code
-                if (process.env.PENTF_SHOW_CODE_FRAMES !== 'false' && !nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(config._rootDir)) {
+                if (process.env.PENTF_SHOW_CODE_FRAMES !== 'false' && !nearestFrame && !/node_modules/.test(frame.fileName) && frame.fileName.startsWith(config.rootDir)) {
                     nearestFrame = frame;
                 }
 

--- a/src/version.js
+++ b/src/version.js
@@ -11,14 +11,14 @@ async function _cmd(cmd, args, options) {
 async function testsVersion(config) {
     try {
         const tagsOutput = await _cmd(
-            'git', ['tag', '--points-at', 'HEAD'], {cwd: config._testsDir});
+            'git', ['tag', '--points-at', 'HEAD'], {cwd: config.rootDir});
         const tags = tagsOutput.split(EOL).filter(line => line);
         const tagsRepr = (tags.length > 0) ? tags.join('/') + '/' : '';
 
         const gitVersion = await _cmd(
             'git', ['show', '--pretty=format:%h (%ai)', '--no-patch', 'HEAD'],
-            {cwd: config._testsDir});
-        const changesOutput = await _cmd('git', ['status', '--porcelain'], {cwd: config._testsDir});
+            {cwd: config.rootDir});
+        const changesOutput = await _cmd('git', ['status', '--porcelain'], {cwd: config.rootDir});
         const changedFiles = (
             changesOutput.split(EOL)
                 .filter(line => line)

--- a/src/watcher.js
+++ b/src/watcher.js
@@ -20,10 +20,10 @@ function removeFromModuleCache(fileName) {
  */
 async function createWatcher(config, onChange) {
     const patterns = [...config.watch_files, config.testsGlob]
-        .map(pattern => path.join(config._testsDir, pattern));
+        .map(pattern => path.join(config.rootDir, pattern));
 
     const watcher = chokidar.watch(patterns, {
-        cwd: config._rootDir,
+        cwd: config.rootDir,
         ignoreInitial: true,
         absolute: true,
     });
@@ -34,7 +34,7 @@ async function createWatcher(config, onChange) {
     });
 
     watcher.on('unlink', fileOrDir => {
-        const absolute = path.join(config._rootDir, fileOrDir);
+        const absolute = path.join(config.rootDir, fileOrDir);
         removeFromModuleCache(absolute);
     });
 
@@ -46,13 +46,13 @@ async function createWatcher(config, onChange) {
             return;
         }
 
-        const absolute = path.join(config._rootDir, fileOrDir);
+        const absolute = path.join(config.rootDir, fileOrDir);
         removeFromModuleCache(absolute);
 
         // Check if we have a test file and if yes, if that file
         // matches the current filter set.
-        let test_cases = await loadTests(config, config._testsDir, config.testsGlob);
-        if (minimatch(absolute, path.join(config._testsDir, config.testsGlob))) {
+        let test_cases = await loadTests(config, config.testsGlob);
+        if (minimatch(absolute, path.join(config.rootDir, config.testsGlob))) {
             test_cases = await applyTestFilters(config, test_cases);
             test_cases = test_cases.filter(tc => tc.fileName === absolute);
         }

--- a/tests/console_navigation/run
+++ b/tests/console_navigation/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/error_output/run
+++ b/tests/error_output/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/esm_tests/run
+++ b/tests/esm_tests/run
@@ -4,6 +4,5 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
     testsGlob: '*.mjs'
 });

--- a/tests/flaky_tests/run
+++ b/tests/flaky_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/glob_tests/run
+++ b/tests/glob_tests/run
@@ -4,6 +4,5 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
     testsGlob: '*.spec.{js,jsx}'
 });

--- a/tests/log_file_tests/run
+++ b/tests/log_file_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/maxEventListeners_tests/run
+++ b/tests/maxEventListeners_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/no_clear_line/run
+++ b/tests/no_clear_line/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/screenshot_tests/run
+++ b/tests/screenshot_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/selftest_loader.js
+++ b/tests/selftest_loader.js
@@ -4,7 +4,13 @@ const {loadTests} = require('../src/loader');
 
 async function run(config) {
     assert.deepStrictEqual(
-        (await loadTests({filter: 'selftest_lo[ao]der'}, config._testsDir, '*.js')).map(
+        (await loadTests(
+            {
+                filter: 'selftest_lo[ao]der',
+                rootDir: config.rootDir
+            },
+            'tests/*.js'
+        )).map(
             t => t.name
         ),
         ['selftest_loader']
@@ -15,9 +21,9 @@ async function run(config) {
         {
             filter: 'selftest_[a-l]',
             filter_body: 'he5Eih1oh+ai8sho',
+            rootDir: config.rootDir,
         },
-        config._testsDir,
-        '*.js'
+        'tests/*.js'
     );
     assert.deepStrictEqual(
         byBody.map(t => t.name),

--- a/tests/selftest_no_config_folder.js
+++ b/tests/selftest_no_config_folder.js
@@ -6,6 +6,7 @@ async function run() {
     assert.deepEqual(config, {
         afterAllTests: undefined,
         beforeAllTests: undefined,
+        rootDir: process.cwd(),
         sentry: undefined,
         sentry_dsn: undefined
     });

--- a/tests/selftest_version.js
+++ b/tests/selftest_version.js
@@ -12,8 +12,7 @@ async function run() {
     await (promisify(child_process.execFile)('tar', ['xf', 'example_repo.tar.gz'], {cwd: scratchDir}));
 
     const pseudoConfig = {
-        rootDir: exampleRepo,
-        _testsDir: path.join(exampleRepo, 'tests'), // This is normally auto-computed by the runner start
+        rootDir: path.join(exampleRepo, 'tests'),
     };
     const v = await testsVersion(pseudoConfig);
     const expectedRegex = /^6f053c5 \((.*?)\)\+changes\(tests\/firsttest.js\)$/;

--- a/tests/skip_tests/run
+++ b/tests/skip_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/suite/run
+++ b/tests/suite/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/timeout_tests/run
+++ b/tests/timeout_tests/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/ts_node/run
+++ b/tests/ts_node/run
@@ -4,5 +4,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/version_pentf/run
+++ b/tests/version_pentf/run
@@ -3,5 +3,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });

--- a/tests/watch_tests/run
+++ b/tests/watch_tests/run
@@ -3,5 +3,4 @@ const pentf = require('../../src/index.js');
 
 pentf.main({
     rootDir: __dirname,
-    testsDir: __dirname,
 });


### PR DESCRIPTION
It's replaced by globs which are for more flexible when the tests files are not in a single folder