### PR TITLE
Fix console.logs messing up status line

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -597,6 +597,8 @@ async function run(config, testCases) {
         last_logged_status: ''
     };
 
+    const restoreConsole = output.proxyConsole(config, state);
+
     if (config.sentry) {
         const sentry_dsn = config.sentry_dsn;
         assert(
@@ -694,6 +696,8 @@ async function run(config, testCases) {
 
         output.logVerbose(config, 'lock & email shutdown complete');
     } finally {
+        restoreConsole();
+
         if (config.afterAllTests) {
             output.logVerbose(config, 'running custom per-project teardown ...');
             await timeoutPromise(

--- a/tests/selftest_console_self.js
+++ b/tests/selftest_console_self.js
@@ -1,0 +1,14 @@
+const { wait } = require('../src/utils');
+
+async function run() {
+    console.log('foo');
+    await wait(200);
+    console.log('foo');
+}
+
+module.exports = {
+    description: 'Test console forwarding',
+    // Can't find an automatic way to test this
+    skip: () => !process.stderr.isTTY || true,
+    run,
+};


### PR DESCRIPTION
Before:

```bash
0/1 done, 1 running (selftest_console_self)foo
foo
  1 tests passed
```

After:

```bash
foo
foo
  1 tests passed
```