### PR TITLE
Remove support for Node 10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [10.x, 11.x, 12.x, 14.x]
+        node-version: [12.x, 14.x]
 
     steps:
       - uses: actions/checkout@v2

--- a/assert_utils.js
+++ b/assert_utils.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/assert_utils');

--- a/browser_console.js
+++ b/browser_console.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/browser_console');

--- a/browser_utils.js
+++ b/browser_utils.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/browser_utils');

--- a/config.js
+++ b/config.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/config');

--- a/curl_command.js
+++ b/curl_command.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/curl_command');

--- a/email.js
+++ b/email.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/email');

--- a/external_locking.js
+++ b/external_locking.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/external_locking');

--- a/loader.js
+++ b/loader.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/loader');

--- a/locking.js
+++ b/locking.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/locking');

--- a/main.js
+++ b/main.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/main');

--- a/net_utils.js
+++ b/net_utils.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/net_utils');

--- a/output.js
+++ b/output.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/output');

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
   "directories": {
     "test": "tests"
   },
+  "engines": {
+    "node": ">=12.0.0"
+  },
   "bin": {
     "pentf": "./bin/cli.js"
   },

--- a/promise_utils.js
+++ b/promise_utils.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/promise_utils');

--- a/render.js
+++ b/render.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/render');

--- a/results.js
+++ b/results.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/results');

--- a/runner.js
+++ b/runner.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/runner');

--- a/tests/selftest_browser_close.js
+++ b/tests/selftest_browser_close.js
@@ -1,6 +1,6 @@
 const assert = require('assert').strict;
-const {newPage} = require('../browser_utils');
-const runner = require('../runner');
+const {newPage} = require('../src/browser_utils');
+const runner = require('../src/runner');
 
 async function run(config) {
     let page;

--- a/utils.js
+++ b/utils.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/utils');

--- a/version.js
+++ b/version.js
@@ -1,2 +1,0 @@
-// Only needed for Node 10 which doesn't support export maps
-module.exports = require('./src/version');


### PR DESCRIPTION
Main reason: Node <=12 doesn't support async stack traces. Since we make heavy use of `async/await` every stack trace will only be one entry long. The current LTS is Node 12, but in just three weeks it will be replaced by Node 14.