### PR TITLE
Add optional success assertion for click functions

### DIFF
--- a/tests/selftest_clickNestedText.js
+++ b/tests/selftest_clickNestedText.js
@@ -76,6 +76,16 @@ async function run(config) {
     await clickNestedText(page, /foo$/);
     assert.deepStrictEqual(clicks, ['clickme', 'clickme']);
 
+    // Option: assertSuccess
+    let success = false;
+    await clickNestedText(page, /^clickme/, {
+        assertSuccess: () => {
+            const old = success;
+            success = !success;
+            return old;
+        }
+    });
+    assert(success, 'assertSuccess was not invoked');
 
     await closePage(page);
 }

--- a/tests/selftest_clickSelector.js
+++ b/tests/selftest_clickSelector.js
@@ -63,6 +63,17 @@ async function run(config) {
         e => e.stack.includes("'invalid[' is not a valid selector")
     );
 
+    // Option: assertSuccess
+    let success = false;
+    await clickSelector(page, 'button#clickme', {
+        assertSuccess: () => {
+            const old = success;
+            success = !success;
+            return old;
+        }
+    });
+    assert(success, 'assertSuccess was not invoked');
+
     await closePage(page);
 }
 

--- a/tests/selftest_clickTestId.js
+++ b/tests/selftest_clickTestId.js
@@ -39,6 +39,17 @@ async function run(config) {
     await clickTestId(page, 'invisible', {visible: false, timeout: 1000});
     assert.deepStrictEqual(clicks, ['invisible']);
 
+    // Option: assertSuccess
+    let success = false;
+    await clickTestId(page, 'first', {
+        assertSuccess: () => {
+            const old = success;
+            success = !success;
+            return old;
+        }
+    });
+    assert(success, 'assertSuccess was not invoked');
+
     await closePage(page);
 }
 

--- a/tests/selftest_clickText.js
+++ b/tests/selftest_clickText.js
@@ -1,0 +1,48 @@
+const assert = require('assert').strict;
+
+const {closePage, newPage, clickText} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    let clicks = [];
+
+    await page.setContent(`
+        <div>
+            <button onclick="pentfClick('first')">first</button>
+            <div data-testid="invisible" style="display:none;" onclick="pentfClick('invisible')">invisible</div>
+        </div>
+    `);
+    await page.exposeFunction('pentfClick', clickId => {
+        clicks.push(clickId);
+    });
+
+    // String variant
+    await clickText(page, 'first');
+    assert.deepStrictEqual(clicks, ['first']);
+
+    clicks = [];
+    await assert.rejects(clickText(page, 'not-present', {timeout: 1, extraMessage: 'blabla'}), {
+        message: 'Unable to find text "not-present" after 1ms (blabla)',
+    });
+    assert.deepStrictEqual(clicks, []);
+
+    // Option: assertSuccess
+    let success = false;
+    await clickText(page, 'first', {
+        assertSuccess: () => {
+            const old = success;
+            success = !success;
+            return old;
+        }
+    });
+    assert(success, 'assertSuccess was not invoked');
+    assert.deepStrictEqual(clicks, ['first']);
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'The clickText browser_utils function clicks elements by matching direct text content',
+    resources: [],
+    run,
+};

--- a/tests/selftest_clickXPath.js
+++ b/tests/selftest_clickXPath.js
@@ -1,0 +1,50 @@
+const assert = require('assert').strict;
+
+const {closePage, newPage, clickXPath} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+
+    const clicks = [];
+    await page.exposeFunction('registerClick', id => clicks.push(id));
+    await page.setContent(`<!DOCTYPE html>
+        <button id="first">click me</button>
+        <div id="second"></div>
+        <script>
+            ["first", "second"].forEach(id => {
+                const el = document.getElementById(id);
+                el.addEventListener("click", e => registerClick(e.target.id));
+            })
+        </script>
+    `);
+
+    assert.rejects(clickXPath(page, '//foo', { timeout: 1 }));
+    assert.deepStrictEqual(clicks, []);
+
+    assert.rejects(clickXPath(page, '//foo', { timeout: 1, message: 'blabla' }), {
+        message: 'blabla'
+    });
+    assert.deepStrictEqual(clicks, []);
+
+    await clickXPath(page, '//button');
+    assert.deepStrictEqual(clicks, ['first']);
+
+    // Option: assertSuccess
+    let success = false;
+    await clickXPath(page, '//button', {
+        assertSuccess: () => {
+            const old = success;
+            success = !success;
+            return old;
+        }
+    });
+    assert(success, 'assertSuccess was not invoked');
+
+    await closePage(page);
+}
+
+module.exports = {
+    description: 'browser_utils.clickXPath to atomically click an element by query selector',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Many frontend frameworks create DOM nodes before attaching event listeners. In those cases we may trigger the click event too early and run into a race condition.

We cannot automatically retry a click, because it can have side effects. Therefore only the user knows under which conditions the check should be retried.

The cypress folks have a fantastic blog post about this problem: https://www.cypress.io/blog/2019/01/22/when-can-the-test-click/