### PR TITLE
Fix watch mode not reloading changed files

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -8,7 +8,7 @@ const path = require('path');
 const {promisify} = require('util');
 
 const utils = require('./utils');
-const { importFile } = require('./loader');
+const { importFile, findPackageJson } = require('./loader');
 
 class AutoWidthArgumentParser extends argparse.ArgumentParser {
     _getFormatter() {
@@ -481,26 +481,6 @@ async function readConfigFile(configDir, env) {
 /**
  * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string}} Config
  */
-
-/**
- * Find nearest `package.json` file
- * @param {string} dir
- * @returns {string | null} Path to package.json or null if not found
- */
-async function findPackageJson(dir) {
-    let fileName = path.join(dir, 'package.json');
-    try {
-        await fs.promises.readFile(fileName);
-        return fileName;
-    } catch(e) {
-        // File doesn't exist, traverse upwards
-        if (e.code === 'ENOENT' && dir !== path.dirname(dir)) {
-            return await findPackageJson(path.dirname(dir));
-        }
-    }
-
-    return null;
-}
 
 /**
  * @param {import('./main').PentfOptions} options


### PR DESCRIPTION
This PR fixes files not being reloaded in watch mode. The heart of the issue is that we only have access to the module cache when we are not in `type: "module"` mode. With native ES-Modules we have [no way to unload a module](https://github.com/nodejs/modules/issues/307) as that's not part of the spec. It defines module loading as being idempotent.

In the long term it looks like we need to switch to workers to be able to unload files. That's something for later though as it requires a bit more thought.

_Note: Had to shuffle the `findPackageJson` function around to avoid a circular import._