### PR TITLE
Fix esm loading regression

### DIFF
--- a/tests/selftest_esm.js
+++ b/tests/selftest_esm.js
@@ -1,7 +1,6 @@
 const assert = require('assert').strict;
 const path = require('path');
 const child_process = require('child_process');
-const { supportsImports } = require('../src/loader');
 
 async function run() {
     // Run in subprocess so that handle exhaustion does not affect this process
@@ -25,6 +24,5 @@ async function run() {
 module.exports = {
     description: 'Test running esm test cases',
     resources: [],
-    skip: async () => !await supportsImports(),
     run,
 };


### PR DESCRIPTION
The check if we should use import was wrong. With support for Node 10 dropped, we can simplify it a lot and avoid potential gotchas.

The regression was introduced in #273 yesterday.