### PR TITLE
Force esm to always use dynamic import

### DIFF
--- a/babel-transform-commonjs-to-esm.js
+++ b/babel-transform-commonjs-to-esm.js
@@ -282,6 +282,18 @@ module.exports = function cjs2esm({types: t}) {
                 },
             },
 
+            StringLiteral(path) {
+                // Replace `const BUILD_TYPE = 'commonjs';` with `const BUILD_TYPE = 'module';`
+                if (
+                    t.isVariableDeclarator(path.parent) &&
+                    t.isIdentifier(path.parent.id) &&
+                    path.parent.id.name === 'BUILD_TYPE' &&
+                    path.node.value === 'commonjs'
+                ) {
+                    path.replaceWith(t.stringLiteral('module'));
+                }
+            },
+
             Directive(path) {
                 // ES Modules are always strict, therefore delete any
                 // present "use strict"; directives

--- a/src/loader.js
+++ b/src/loader.js
@@ -28,6 +28,12 @@ async function findPackageJson(dir) {
 let moduleType;
 
 /**
+ * Will be set during compilation. Prevents ESM modules trying to use
+ * `require` for loading modules
+ */
+const BUILD_TYPE = 'commonjs';
+
+/**
  * Load module via CommonJS or ES Modules depending on the environment
  * @param {string} file
  */
@@ -43,7 +49,7 @@ async function importFile(file) {
     // tools like `ts-node´ need to keep using `require` calls.
     // Note that we still need to forward loading from `node_modules`
     // to `import()` regardless.
-    if (moduleType === 'module' || /\.mjs$/.test(file)) {
+    if (BUILD_TYPE === 'module' || moduleType === 'module' || /\.mjs$/.test(file)) {
         // Use dynamic import statement to be able to load both native esm
         // and commonjs modules.
 


### PR DESCRIPTION
Missed an edge case where a `commonjs` project may load a `.mjs` file and we therefore switches to `esm`. We **must not** fall back to `commonjs` and always use `import()` from then on.