### PR TITLE
Load module type upfront

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -49,9 +49,9 @@ async function newPage(config, chrome_args=[]) {
     let puppeteer;
     try {
         if(config.puppeteer_firefox) {
-            puppeteer = await importFile('puppeteer-firefox');
+            puppeteer = await importFile('puppeteer-firefox', config.moduleType);
         } else {
-            puppeteer = await importFile('puppeteer');
+            puppeteer = await importFile('puppeteer', config.moduleType);
         }
     } catch(e) {
         // puppeteer/puppeteer-firefox is a peer dependency. Show a helpful error message when it's missing.

--- a/tests/selftest_config.js
+++ b/tests/selftest_config.js
@@ -4,7 +4,7 @@ const {_readConfigFile: readConfigFile} = require('../src/config');
 
 async function run() {
     const exampleDir = path.join(__dirname, 'config_examples');
-    const exampleConfig = await readConfigFile(exampleDir, 'json');
+    const exampleConfig = await readConfigFile(exampleDir, 'json', 'commonjs');
 
     assert(exampleConfig.json_loaded);
     assert(exampleConfig.simple_loaded);

--- a/tests/selftest_loader.js
+++ b/tests/selftest_loader.js
@@ -7,7 +7,8 @@ async function run(config) {
         (await loadTests(
             {
                 filter: 'selftest_lo[ao]der',
-                rootDir: config.rootDir
+                rootDir: config.rootDir,
+                moduleType: 'commonjs'
             },
             'tests/*.js'
         )).map(
@@ -22,6 +23,7 @@ async function run(config) {
             filter: 'selftest_[a-l]',
             filter_body: 'he5Eih1oh+ai8sho',
             rootDir: config.rootDir,
+            moduleType: 'commonjs'
         },
         'tests/*.js'
     );

--- a/tests/selftest_no_config_folder.js
+++ b/tests/selftest_no_config_folder.js
@@ -7,6 +7,7 @@ async function run() {
         afterAllTests: undefined,
         beforeAllTests: undefined,
         rootDir: process.cwd(),
+        moduleType: 'commonjs',
         sentry: undefined,
         sentry_dsn: undefined
     });


### PR DESCRIPTION
This prevents an error where importFile() tried to find the module type when importing a node-specifier like "puppeteer". In those case we don' have a folder to start the lookup and we'd silently fail. We already _have_ a reference to the package.json during initial config loading, so we can load that information there and just pass it as an argument to `importFile()`.