### PR TITLE
Do not try to parse test results if runner terminated because of CLI option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -31,8 +31,7 @@ async function runTests(config, test_cases) {
 
         // Run tests
         const test_info = await runner.run(config, test_cases);
-        if (!test_info) {
-            logVerbose(config, '[runner] No run information returned by runner');
+        if (!test_info) { // Runner terminated early (e.g. --list-locks)
             return;
         }
 
@@ -123,7 +122,7 @@ async function real_main(options={}) {
     } else {
         const results = await runTests(config, test_cases);
 
-        if (!config.keep_open) {
+        if (!config.keep_open && results) {
             const anyErrors = results.tests.some(s => s.status === 'error' && !s.expectedToFail);
             const retCode = (!anyErrors || config.exit_zero) ? 0 : 3;
             logVerbose(`Terminating with exit code ${retCode}`);


### PR DESCRIPTION
When `--list-locks` or so is given, the runner returns `undefined`, and that is correct, because no tests were run.
Correct handling of this.

Fixes #281
