### PR TITLE
Report CPU Count

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -32,12 +32,17 @@ function listEnvs(configDir) {
     return res;
 }
 
+function getCPUCount() {
+    return os.cpus().length;
+    // TODO handle scenarios where our process is limited to less
+}
+
 function computeConcurrency(spec, {cpuCount=undefined}={}) {
     if (typeof spec === 'number') { // Somebody passed in result value directly
         return spec;
     }
     if (cpuCount === undefined) {
-        cpuCount = os.cpus().length;
+        cpuCount = getCPUCount();
     }
 
     return spec.split('+').map(
@@ -540,6 +545,7 @@ module.exports = {
     listEnvs,
     parseArgs,
     readConfig,
+    getCPUCount,
     // tests only
     _readConfigFile: readConfigFile,
     _computeConcurrency: computeConcurrency,

--- a/src/render.js
+++ b/src/render.js
@@ -206,7 +206,7 @@ function markdown(results) {
 ${report_header_md}
 ### Options
 Tested Environment: **${results.config.env}**
-Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.concurrency}
+Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.concurrency}${results.cpuCount ? ' (' + results.cpuCount + ' CPUs)' : ''}
 ${((results.config.repeat || 1) > 1) ?
         'Each test repeated **' + escape_html(results.config.repeat + '') + '** times  \n' : ''
 }Start: ${format_timestamp(results.start)}
@@ -451,7 +451,7 @@ td.test_footer {
 ${report_header_html}
 <h2>Options</h2>
 <p>Tested Environment: <strong>${results.config.env}</strong><br/>
-Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.concurrency}<br/>
+Concurrency: ${results.config.concurrency === 0 ? 'sequential' : results.config.concurrency}${results.cpuCount ? ' (' + results.cpuCount + ' CPUs)' : ''}<br/>
 ${((results.config.repeat || 1) > 1) ? 'Each test repeated <strong>' + escape_html(results.config.repeat + '') + '</strong> times<br/>' : ''}
 Start: ${format_timestamp(results.start)}<br/>
 Version: ${results.testsVersion}, pentf ${results.pentfVersion}<br/>

--- a/src/runner.js
+++ b/src/runner.js
@@ -15,6 +15,7 @@ const output = require('./output');
 const utils = require('./utils');
 const version = require('./version');
 const {timeoutPromise} = require('./promise_utils');
+const { getCPUCount } = require('./config');
 const { shouldShowError } = require('./output');
 
 /**
@@ -713,8 +714,10 @@ async function run(config, testCases) {
     const testsVersion = await timeoutPromise(
         config, version.testsVersion(config), {message: 'version determination', warning: true});
     const pentfVersion = version.pentfVersion();
+    const cpuCount = getCPUCount();
 
     return {
+        cpuCount,
         test_start,
         test_end,
         pentfVersion,


### PR DESCRIPTION
Include the CPU count in the rendered PDF. This can help to diagnose running on the wrong runner in a CI environment.
