### PR TITLE
Re-run tests on pressing enter in watch mode

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -1,6 +1,7 @@
 const path = require('path');
 const minimatch = require('minimatch');
 const chokidar = require('chokidar');
+const readline = require('readline');
 
 const output = require('./output');
 const {loadTests, applyTestFilters} = require('./loader');
@@ -14,13 +15,64 @@ function removeFromModuleCache(fileName) {
 }
 
 /**
+ * @typedef {{running: boolean, last_changed_file: string}} WatchState
+ */
+
+/**
+ * @param {import('./config').Config} config
+ * @param {WatchState} state
+ * @param {(test_cases: import('./runner').TestCase[]) => Promise<void>} onChange
+ */
+async function scheduleRun(config, state, onChange) {
+    // Bail out if there is a run in progress.
+    // TODO: Add proper cancellation for pending runs.
+    if (state.running) {
+        return;
+    }
+
+    const absolute = path.join(config.rootDir, state.last_changed_file);
+    if (state.last_changed_file) {
+        removeFromModuleCache(absolute);
+    }
+
+    let test_cases = await loadTests(config, config.testsGlob);
+    test_cases = await applyTestFilters(config, test_cases);
+    if (minimatch(absolute, path.join(config.rootDir, config.testsGlob))) {
+        test_cases = test_cases.filter(tc => tc.fileName === absolute);
+    }
+
+    // Bail out if there are no tests to run
+    if (test_cases.length === 0) {
+        return;
+    }
+
+    state.running = true;
+
+    if (!config.ci) console.clear();
+    try {
+        if (state.last_changed_file) {
+            const suffix = output.color(config, 'lightCyan', 'Updated');
+            output.log(config, `${suffix} ${state.last_changed_file}`);
+        } else {
+            const suffix = output.color(config, 'lightCyan', 'Re-Run');
+            output.log(config, `${suffix} tests`);
+        }
+        await onChange(test_cases);
+    } catch (err) {
+        console.log(err);
+    }
+    state.running = false;
+}
+
+/**
  * @param {import('./config').Config} config
  * @param {string[]} patterns
  * @param {(test_cases: import('./runner').TestCase[]) => Promise<void>} onChange
  */
 async function createWatcher(config, onChange) {
-    const patterns = [...config.watch_files, config.testsGlob]
-        .map(pattern => path.join(config.rootDir, pattern));
+    const patterns = [...config.watch_files, config.testsGlob].map(pattern =>
+        path.join(config.rootDir, pattern)
+    );
 
     const watcher = chokidar.watch(patterns, {
         cwd: config.rootDir,
@@ -38,41 +90,34 @@ async function createWatcher(config, onChange) {
         removeFromModuleCache(absolute);
     });
 
-    let isRunning = false;
+    /** @type {WatchState} */
+    const watchState = {
+        last_changed_file: '',
+        running: false,
+    };
+
+    // Initialize keypress event listeners to stdin stream
+    readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    // Only for tests, can't simulate keycodes without a proper TTY
+    process.stdin.on('data', async e => {
+        if (Buffer.isBuffer(e) && e.toString() === String.fromCharCode(13) && !watchState.running) {
+            await scheduleRun(config, watchState, onChange);
+        }
+    });
+
+    process.stdin.on('keypress', async (_, key) => {
+        if (key.name === 'return' && !watchState.running) {
+            await scheduleRun(config, watchState, onChange);
+        }
+    });
+
     watcher.on('change', async fileOrDir => {
-        // Bail out if there is a run in progress.
-        // TODO: Add proper cancellation for pending runs.
-        if (isRunning) {
-            return;
-        }
-
-        const absolute = path.join(config.rootDir, fileOrDir);
-        removeFromModuleCache(absolute);
-
-        // Check if we have a test file and if yes, if that file
-        // matches the current filter set.
-        let test_cases = await loadTests(config, config.testsGlob);
-        if (minimatch(absolute, path.join(config.rootDir, config.testsGlob))) {
-            test_cases = await applyTestFilters(config, test_cases);
-            test_cases = test_cases.filter(tc => tc.fileName === absolute);
-        }
-
-        // Bail out if there are no tests to run
-        if (test_cases.length === 0) {
-            return;
-        }
-
-        isRunning = true;
-
-        if (!config.ci) console.clear();
-        try {
-            const suffix = output.color(config, 'lightCyan', 'Updated');
-            output.log(config, `${suffix} ${fileOrDir}`);
-            await onChange(test_cases);
-        } catch (err) {
-            console.log(err);
-        }
-        isRunning = false;
+        watchState.last_changed_file = fileOrDir;
+        await scheduleRun(config, watchState, onChange);
     });
 }
 

--- a/tests/selftest_watch_enter.js
+++ b/tests/selftest_watch_enter.js
@@ -1,0 +1,32 @@
+const child_process = require('child_process');
+const path = require('path');
+const {assertEventually} = require('../src/assert_utils');
+const {onTeardown} = require('../src/runner');
+
+async function run(config) {
+    const sub_run = path.join(__dirname, 'watch_tests', 'run');
+    const child = child_process.spawn(sub_run, ['--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
+    onTeardown(config, () => child.kill());
+
+    const out = [];
+
+    child.stdout.on('data', data => out.push(data.toString()));
+    child.stderr.on('data', data => out.push(data.toString()));
+
+    await assertEventually(() => {
+        return out.find(msg => /Waiting for file changes/.test(msg));
+    });
+
+    // Simulate enter keycode
+    child.stdin.write(String.fromCharCode(13));
+
+    // Make sure only one test is run
+    await assertEventually(() => {
+        return out.find(msg => /1 tests passed/.test(msg));
+    });
+}
+
+module.exports = {
+    run,
+    description: 'Re-run test when pressing enter',
+};


### PR DESCRIPTION
Like the title says: This PR allows the user to press enter during watch mode to re-run the tests with the current filter set.

This addresses one point mentioned in #284