### PR TITLE
Allow setting retryTimes per test case

### DIFF
--- a/src/loader.js
+++ b/src/loader.js
@@ -241,7 +241,12 @@ async function loadTests(config, globPattern) {
             } else if (typeof tc.run === 'function') {
                 // ESM modules are readonly, so we need to create our own writable
                 // object.
-                testCases.push({...tc, name: t.name, fileName: t.fileName});
+                testCases.push({
+                    ...tc,
+                    name: t.name,
+                    fileName: t.fileName,
+                    retryTimes: tc.retryTimes || 0
+                });
             } else {
                 output.log(config, output.color(config, 'red', `No tests found in file "${t.fileName}", skipping.`));
             }

--- a/tests/selftest_flaky_local.js
+++ b/tests/selftest_flaky_local.js
@@ -1,0 +1,68 @@
+const assert = require('assert').strict;
+const runner = require('../src/runner');
+const render = require('../src/render');
+
+/**
+ * @param {import('../src/runner').TaskConfig} config
+ */
+async function run(config) {
+    let output = [];
+    const runnerConfig = {
+        ...config,
+        colors: false,
+        logFunc: (_, message) => output.push(message),
+        quiet: false,
+    };
+
+
+    function createTests() {
+        let i = 0;
+        /** @type {import('../src/runner').TestCase[]} */
+        return [
+            {
+                name: 'foo',
+                retryTimes: 3,
+                run: async () => {
+                    i++;
+                    if (i < 3) {
+                        throw new Error('fail');
+                    }
+                },
+            },
+        ];
+    }
+
+    function assertResult(test_info) {
+        const result = render.craftResults(config, test_info);
+        const formatted = result.tests.map(t => {
+            return {
+                id: t.id,
+                status: t.status,
+                runs: t.taskResults.length,
+            };
+        });
+
+        assert.deepEqual(formatted, [
+            {id: 'foo', status: 'flaky', runs: 3},
+        ]);
+    }
+
+    // Sequential run
+    let tests = createTests();
+    output = [];
+    let result = await runner.run({...runnerConfig, concurrency: 1}, tests);
+    assertResult(result);
+    assert(output[output.length-1].includes('1 flaky (foo)'), 'Summary did not include flaky tests');
+
+    // Parallel run
+    tests = createTests();
+    output = [];
+    result = await runner.run({...runnerConfig, concurrency: 1}, tests);
+    assertResult(result);
+    assert(output[output.length-1].includes('1 flaky (foo)'), 'Summary did not include flaky tests');
+}
+
+module.exports = {
+    run,
+    descripton: 'Rerun task max 3 times',
+};


### PR DESCRIPTION
This PR allows setting the retry count on a per test case basis instead of only globally via the `--repeat-flaky` flag.

Example:

```js
module.exports = {
  run,
  description: "My cool test case",
  retryTimes: 3 // Automatically retry test max 3 times or until it succeeds
}
```