### PR TITLE
Add support for toggling debug mode during watch

### DIFF
--- a/src/watcher.js
+++ b/src/watcher.js
@@ -32,6 +32,11 @@ function keyHint(config, key, description) {
  */
 function watchFooter(config) {
     let out = '\n';
+    if (config.debug) {
+        out += output.color(config, 'reset', 'Debug mode: ');
+        out += output.color(config, 'yellow', 'enabled') + '\n\n';
+    }
+
     if (config.filter) {
         out += output.color(config, 'reset', 'Active filter: ');
         out += output.color(config, 'yellow', config.filter) + '\n';
@@ -41,6 +46,7 @@ function watchFooter(config) {
     out += [
         keyHint(config, 'a', 'to re-run all tests'),
         keyHint(config, 'p', 'to search by file pattern'),
+        keyHint(config, 'd', `to ${config.debug ? 'disable' : 'enable'} debug mode`),
         keyHint(config, 'q', 'to quit watch mode'),
         keyHint(config, 'Enter', 'to re-run current tests'),
     ].join('\n');
@@ -236,6 +242,15 @@ async function createWatcher(config, onChange) {
                 watchState.selected_file = null;
                 watchState.selected_row = 0;
                 watchState.selection_active = false;
+                renderDefault(config);
+            } else if (key.name === 'd') {
+                const enabled = !config.debug;
+                config.headless = !enabled;
+                config.debug = enabled;
+                config.devtools = enabled;
+                config.devtools_preserve = enabled;
+                config.keep_open = enabled;
+                config.forward_console = enabled;
                 renderDefault(config);
             } else if (key.name === 'p') {
                 watchState.current_view = 'pattern';

--- a/tests/selftest_watch_pattern.js
+++ b/tests/selftest_watch_pattern.js
@@ -101,6 +101,12 @@ async function run(config) {
     await type(child, 'c', /(?!Active filter)/i);
     await type(child, 'p', /Start typing to filter/);
     await type(child, '*', /Pattern contains invalid characters/);
+
+    await type(child, ESCAPE, /waiting for file changes/i);
+    
+    // Toggle debug mode
+    await type(child, 'd', /Debug mode:/i);
+    await type(child, 'd', /(?!Debug mode:)/i);
 }
 
 module.exports = {


### PR DESCRIPTION
This PR adds support for toggling debug mode by pressing `d` during watch mode.

![image](https://user-images.githubusercontent.com/1062408/103485035-a83e9f00-4df3-11eb-906a-028ce5dcaac5.png)
