### PR TITLE
Add support for asserting accessibility violations

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -867,6 +867,11 @@
       "dev": true,
       "optional": true
     },
+    "axe-core": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+      "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ=="
+    },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "@types/glob": "^7.1.1",
     "@types/puppeteer": "^5.4.0",
     "argparse": "^1.0.10",
+    "axe-core": "^4.1.1",
     "chokidar": "^3.4.2",
     "diff": "^4.0.2",
     "emailjs-imap-client": "^3.0.7",

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -1176,15 +1176,17 @@ async function assertAccessibility(config, page) {
             let imgs = [];
             if (node.ancestry) {
                 // We can't postpone taking screenshots as the html may change later
-                const name = `${config._taskName}-a11y-${i++}`;
-                imgs = await Promise.all(node.ancestry.map(async selector => {
+                for (const selector of node.ancestry) {
+                    const name = `${config._taskName}-a11y-${i++}`;
+
                     try {
-                        return await takeScreenshot(config, page, name, selector);
+                        const img = await takeScreenshot(config, page, name, selector);
+                        imgs.push(img);
                     } catch (err) {
                         output.logVerbose(config, '[runner] Could not take screenshot ' + err.message);
                         return null;
                     }
-                }));
+                }
             }
 
             nodes.push({

--- a/tests/selftest_accessibility.js
+++ b/tests/selftest_accessibility.js
@@ -1,0 +1,19 @@
+const {newPage, assertAccessibility} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.setContent('<div style="width: 300px; height: 300px; background: red;"><blink></blink></div>');
+
+    try {
+        await assertAccessibility(config, page);
+    } catch (err) {
+        if (!/5 accessibility violations/.test(err.message)) {
+            throw err;
+        }
+    }
+}
+
+module.exports = {
+    description: 'Test accessibility violations',
+    run,
+};


### PR DESCRIPTION
This PR integrates `axe-core` for doing accessibility tests into pentf. Users can assert how accessible a page or frame is by calling `assertAccessibility(config, page)`. If there are any resulting violations they will be shown up in stdout as well as in the generated PDF file. Each violation contains a short description and a link to a detailed one.

FYI: There is an actual screenshot instead of a black rectangle.

CLI-Output:
![screen3](https://user-images.githubusercontent.com/1062408/104026158-d9d5b280-51c5-11eb-9e88-552ec606e98b.png)


PDF-Output:
![screen2](https://user-images.githubusercontent.com/1062408/104026178-dfcb9380-51c5-11eb-90a9-5e518c4fec83.png)

