### PR TITLE
Expose task error for teardown functions

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -38,6 +38,7 @@ function onTeardown(config, callback) {
  * @property {string} _testName
  * @property {string} _taskName
  * @property {string} _taskGroup
+ * @property {Error | null} error
  * @property {import('./browser_utils').A11yResult[]} accessibilityErrors
  */
 
@@ -63,6 +64,7 @@ async function run_task(config, state, task) {
         _taskGroup: task.group,
         start: task.start,
         accessibilityErrors: [],
+        error: null,
     };
     let timeout;
     try {
@@ -110,6 +112,7 @@ async function run_task(config, state, task) {
 
         task.duration = performance.now() - task.start;
         task.error = e;
+        task_config.error = e;
         task.breadcrumb = task_config._breadcrumb;
         task.status = 'error';
         task.accessibilityErrors = task_config.accessibilityErrors;
@@ -197,7 +200,7 @@ async function run_task(config, state, task) {
             output.logVerbose(config, `[runner] Executing ${task_config._teardown_hooks.length} teardown hooks`);
             try {
                 // Run teardown functions if there are any
-                const teardownPromise = Promise.all(task_config._teardown_hooks.map(fn => fn(config)));
+                const teardownPromise = Promise.all(task_config._teardown_hooks.map(fn => fn(task_config)));
                 await timeoutPromise(
                     config,
                     teardownPromise,

--- a/tests/selftest_teardown_task_error.js
+++ b/tests/selftest_teardown_task_error.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const path = require('path');
+const child_process = require('child_process');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'teardown_task_error', 'run');
+    const {stdout} = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--no-screenshots', '-v'],
+            { cwd: path.dirname(sub_run) },
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    assert(/Teardown success/.test(stdout), 'teardown functions should pass');
+}
+
+module.exports = {
+    run,
+    description: 'Call teardown functions with task error'
+};

--- a/tests/teardown_task_error/run
+++ b/tests/teardown_task_error/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+});

--- a/tests/teardown_task_error/teardown.js
+++ b/tests/teardown_task_error/teardown.js
@@ -1,0 +1,17 @@
+const assert = require('assert').strict;
+const { onTeardown } = require('../../src/runner');
+
+async function run(config) {
+    onTeardown(config, (config) => {
+        assert(config.error, 'Task error was not found in task_config object');
+        assert.strictEqual(config.error.message, 'fail');
+        console.log('Teardown success');
+    });
+
+    throw new Error('fail');
+}
+
+module.exports = {
+    run,
+    description: 'Call teardown functions with task error'
+};


### PR DESCRIPTION
This PR exposes the `Error` object of a failed task in `task_config` so that any teardown hooks can decide to apply a different teardown based on if a task failed.