### PR TITLE
Include screenshots of open popup windows

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -213,6 +213,10 @@ async function newPage(config, chrome_args=[]) {
 
     if (config._browser_pages) {
         config._browser_pages.push(page);
+
+        page.on('popup', popup => {
+            config._browser_pages.push(popup);
+        });
     }
 
     if (config.breadcrumbs) {

--- a/src/runner.js
+++ b/src/runner.js
@@ -142,7 +142,7 @@ async function run_task(config, state, task) {
             } catch(e) {
                 output.log(
                     config,
-                    `INTERNAL ERROR: failed to take screenshot of #${task.id} (${task.name}): ${e}`);
+                    `INTERNAL ERROR: failed to take screenshot of #${task.id} (${task.name}): ${e}\n${e.stack}`);
             }
         }
         // Close all browser windows
@@ -154,7 +154,7 @@ async function run_task(config, state, task) {
             try {
                 await Promise.all(task_config._browser_pages.slice().map(page => browser_utils.closePage(page)));
             } catch(e) {
-                output.log(config, `INTERNAL ERROR: Unable to close browser pages of ${task.name}: ${e}`);
+                output.log(config, `INTERNAL ERROR: Unable to close browser pages of ${task.name}: ${e}\n${e.stack}`);
             }
         }
 

--- a/tests/screenshot_popup_tests/error.js
+++ b/tests/screenshot_popup_tests/error.js
@@ -1,0 +1,33 @@
+const {newPage, interceptRequest} = require('../../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config, ['--disable-features=IsolateOrigins,site-per-process']);
+    await interceptRequest(page, request => {
+        if (request.url() === 'https://example.com') {
+            request.respond({
+                body: '<h1>Popup</h1>',
+                contentType: 'text/html'
+            });
+        } else {
+            request.continue();
+        }
+
+    });
+    page.setContent(`
+        <a href="https://example.com" target="_blank">link</a>
+    `);
+
+    const [popup] = await Promise.all([
+        new Promise(resolve => page.once('popup', resolve)),
+        page.click('a[target=_blank]'),
+    ]);
+
+    await popup.waitForSelector('h1', { timeout: 1500 });
+
+    throw new Error('fail');
+}
+
+module.exports = {
+    description: 'Force popup screenshot generation',
+    run,
+};

--- a/tests/screenshot_popup_tests/run
+++ b/tests/screenshot_popup_tests/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+});

--- a/tests/selftest_popup_screenshot.js
+++ b/tests/selftest_popup_screenshot.js
@@ -1,0 +1,43 @@
+const assert = require('assert').strict;
+const path = require('path');
+const fs = require('fs');
+const child_process = require('child_process');
+const rimrafCb = require('rimraf');
+const {promisify} = require('util');
+
+const rimraf = promisify(rimrafCb);
+
+async function run() {
+    const fixture = path.join(__dirname, 'screenshot_popup_tests');
+
+    const json_file = path.join(fixture, 'results.json');
+    const screenshot_dir = path.join(fixture, 'screenshot_directory');
+
+    await rimraf(json_file);
+    await rimraf(screenshot_dir);
+
+    const sub_run = path.join(fixture, 'run');
+    await new Promise((resolve, reject) => {
+        child_process.execFile(
+            sub_run,
+            ['--exit-zero', '--json', '-v'],
+            { cwd: path.dirname(sub_run) },
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+
+    const json = JSON.parse(await fs.promises.readFile(json_file, 'utf-8'));
+    const screenshots = json.tests[0].taskResults[0].error_screenshots;
+
+    assert.equal(screenshots.length, 2);
+    assert.equal(screenshots[0].type, 'Buffer');
+    assert.equal(screenshots[1].type, 'Buffer');
+}
+
+module.exports = {
+    description: 'Include screenshots of popups on error',
+    run,
+};


### PR DESCRIPTION
If a popup was opened via `window.open()` we would not include a screenshot of that frame in our reporters. Popup windows are actual pages themselves internally in `puppeteer`, so we can safely store them along with our "normal" pages.

The PayPal integration is probably one of the most popular users of the `window.open()`-API. With this PR we'll include a screenshot of the PayPal popup window content in our error output.