### PR TITLE
Fix retryUntil failing when original selector is not present

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -648,7 +648,7 @@ async function clickSelector(page, selector, {timeout=getDefaultTimeout(page), c
         }
 
         try {
-            if (found && (await onSuccess(retryUntil || assertSuccess))) {
+            if ((found || (!found && retryUntilError !== null)) && (await onSuccess(retryUntil || assertSuccess))) {
                 const config = getBrowser(page)._pentf_config;
                 addBreadcrumb(config, `exit clickSelector(${selector})`);
                 return;
@@ -746,7 +746,7 @@ async function clickXPath(page, xpath, {timeout=getDefaultTimeout(page), checkEv
         }
 
         try {
-            if (found && await onSuccess(retryUntil || assertSuccess)) {
+            if ((found || (!found && retryUntilError !== null)) && await onSuccess(retryUntil || assertSuccess)) {
                 addBreadcrumb(config, `exit clickXPath(${xpath})`);
                 return;
             }
@@ -905,7 +905,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=getDefaultTimeout(pa
         }
 
         try {
-            if (found && await onSuccess(retryUntil || assertSuccess)) {
+            if ((found || (!found && retryUntilError !== null)) && await onSuccess(retryUntil || assertSuccess)) {
                 addBreadcrumb(config, `exit clickNestedText(${textOrRegExp})`);
                 return;
             }

--- a/tests/selftest_assertSuccess.js
+++ b/tests/selftest_assertSuccess.js
@@ -32,17 +32,44 @@ async function testFn(fn) {
 
 async function run(config) {
     const page = await newPage(config);
-    await page.setContent(`
+    const content = `
         <div>
             <button onclick="pentfClick('first')">first</button>
             <div data-testid="invisible" style="display:none;" onclick="pentfClick('invisible')">invisible</div>
         </div>
-    `);
+    `;
+    await page.setContent(content);
 
     await testFn((options) => clickSelector(page, 'button', options));
     await testFn((options) => clickXPath(page, '//button', options));
     await testFn((options) => clickText(page, 'first', options));
     await testFn((options) => clickNestedText(page, 'first', options));
+
+    // Should succeed when original elements are removed, but the
+    // callback function passes.
+    let visible = true;
+    const retryUntil = async () => {
+        if (visible) {
+            await page.setContent('<div></div>');
+            visible = false;
+            return false;
+        }
+        return true;
+    };
+
+    await clickSelector(page, 'button', {retryUntil});
+
+    await page.setContent(content);
+    visible = true;
+    await clickXPath(page, '//button', {retryUntil});
+
+    await page.setContent(content);
+    visible = true;
+    await clickText(page, 'first', {retryUntil});
+
+    await page.setContent(content);
+    visible = true;
+    await clickNestedText(page, 'first', {retryUntil});
 
     await closePage(page);
 }


### PR DESCRIPTION
Previously we always aborted if we couldn't find the original selector. This causes problems when the page navigates and the original selector is not present anymore after the click.