### PR TITLE
Fix invalid characters in generated email addresses

### DIFF
--- a/src/email.js
+++ b/src/email.js
@@ -184,7 +184,7 @@ async function getMail(
         }
     }
 
-    output.logVerbose(config, `[email] Waiting for message to arrive... (${config._taskName})`);
+    output.logVerbose(config, `[email] Waiting for message to arrive ${to}... (${config._taskName})`);
     const msg = await utils.retry(
         () => _find_message(config, client, since, to, subjectContains), wait_times);
     assert(msg, (

--- a/src/utils.js
+++ b/src/utils.js
@@ -14,10 +14,15 @@ function makeEmailAddress(config, suffix) {
                            If no prefix is specified, the test name is used if available.
  * @returns {string} If `config.email` is `'foo@bar.com'`, something like `foo+prefix129ad12@bar.com`
  */
-function makeRandomEmail(config, prefix=undefined) {
+function makeRandomEmail(config, prefix) {
     if (prefix === undefined) {
         prefix = config._testName || '';
     }
+
+    // Some providers can't deal with "[" and "]", which we'll add if tests are repeated
+    // See: https://stackoverflow.com/a/2049510
+    prefix = prefix.replace(/[[\]]/g, '_');
+
     return makeEmailAddress(config, prefix + Math.random().toString(36).slice(2));
 }
 

--- a/tests/selftest_makeRandomEmail.js
+++ b/tests/selftest_makeRandomEmail.js
@@ -9,6 +9,9 @@ async function run(config) {
 
     assertIncludes(makeRandomEmail(testConfig, 'foobar'), '+foobar');
     assertIncludes(makeRandomEmail(testConfig), '+selftest_makeRandomEmail');
+
+    // Strips invalid characters
+    assertIncludes(makeRandomEmail(testConfig, 'foo[0]'), 'john.smith+foo_0_');
 }
 
 module.exports = {


### PR DESCRIPTION
When we repeat tests we usually append a suffix to the test name like `[2]`. The generated email address will be based on that and appends a hash to it. Turns out that having `[` or `]` in the address isn't really supported, except im some edge cases. See this thread on SO: https://stackoverflow.com/a/2049510

This was the reason emails didn't come through and I can confirm that they reach their destination with this fix in place in our `dev` environment.