### PR TITLE
Types: Fix no intellisense for package entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.8.6",
   "description": "parallel end-to-end test framework",
   "main": "src/index.js",
-  "types": "dist/types/index.d.ts",
+  "types": "dist/types/__index.d.ts",
   "directories": {
     "test": "tests"
   },
@@ -137,7 +137,7 @@
   "scripts": {
     "test": "./run",
     "lint": "eslint . run",
-    "types": "tsc && cp dist/types/* .",
+    "types": "tsc && node patch-types.js",
     "build": "babel --out-dir dist/ --out-file-extension .mjs src/*.js",
     "clean": "rimraf doc dist *.d.ts",
     "prepublishOnly": "npm run clean && npm run types && npm run build"

--- a/patch-types.js
+++ b/patch-types.js
@@ -1,0 +1,26 @@
+const fs = require('fs');
+const path = require('path');
+
+function addModule(name, content) {
+    const type = content
+        .replace(/declare function/g, 'function')
+        .split('\n').map(x => '    ' + x).join('\n');
+
+    return `\ndeclare module "${name}" {\n${type}\n}\n`;
+}
+
+const entries = Object.keys(require('./package.json').exports)
+    .filter(x => x !== './package.json' && x !== './');
+
+let main = '';
+
+for (const entry of entries) {
+    const name = entry === '.' ? 'index' : entry.slice(2);
+    const type = fs.readFileSync(path.join(__dirname, 'dist', 'types', name + '.d.ts'), 'utf-8');
+    const mod = name === 'index' ? 'pentf' : 'pentf/' + name;
+    main += addModule(mod, type);
+}
+
+const target = path.join(__dirname, 'dist', 'types', '__index.d.ts');
+fs.writeFileSync(target, main);
+

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -1002,6 +1002,7 @@ async function assertNotTestId(page, testId, {timeout=getDefaultTimeout(page), m
  *
  * @param {import('puppeteer').Page} page puppeteer page object.
  * @param {string} selector selector [CSS selector](https://www.w3.org/TR/2018/REC-selectors-3-20181106/#selectors) (aka query selector) of the element to type in.
+ * @param {string} text Text to type
  * @param {{message?: string, timeout?: number}} [__namedParameters] Options (currently not visible in output due to typedoc bug)
  * @param {number?} timeout How long to wait, in milliseconds.
  * @param {string?} message Message shown if the element can not be found.

--- a/src/promise_utils.js
+++ b/src/promise_utils.js
@@ -98,7 +98,7 @@ async function expectedToFail(config, message, asyncFunc, {expectNothing=false} 
  *
  * @param {*} config The pentf configuration.
  * @param {Promise} promise The promise to limit
- * @param {{expectNothing?: boolean, timeout?: number, warning?: number}} __namedParameters Options (currently not visible in output due to typedoc bug)
+ * @param {{expectNothing?: boolean, timeout?: number, warning?: number, message?: string}} __namedParameters Options (currently not visible in output due to typedoc bug)
  * @param {number} timeout Timeout in ms (by default 10000=10s)
  * @param {string} message Optional error message to show when the timeout fires.
  * @param {boolean} warning Only print an error message, do not throw.


### PR DESCRIPTION
TypeScript doesn't support package export maps yet. Therefore it doesn't know about entries, other then the one listed in "types". Using explicit declare module declarations works around that limitation. As a plus we don't need to copy all the `.d.ts` files over to the project root folder 👍 