### PR TITLE
Fix able to click on hidden elements

### DIFF
--- a/tests/selftest_browser.js
+++ b/tests/selftest_browser.js
@@ -57,7 +57,7 @@ async function run(config) {
         </html>
     `);
     await clickXPath(page, '//button[@id="clickme"]');
-    assert.strictEqual(clickCount, 1, 'expected 1 click');
+    await assertEventually(() => clickCount === 1, {message: 'expected 1 click, but got ' + clickCount});
     await assert.rejects(clickXPath(page, '//notfound', {timeout: 10}), {
         message: 'Unable to find XPath //notfound after 10ms',
     });

--- a/tests/selftest_clickText.js
+++ b/tests/selftest_clickText.js
@@ -1,5 +1,5 @@
 const assert = require('assert').strict;
-
+const {assertEventually} = require('pentf/assert_utils');
 const {closePage, newPage, clickText} = require('../src/browser_utils');
 
 async function run(config) {
@@ -38,7 +38,11 @@ async function run(config) {
         }
     });
     assert(called, 'assertSuccess was not invoked');
-    assert.deepStrictEqual(clicks, ['first', 'first']);
+
+    await assertEventually(() => {
+        assert.deepStrictEqual(clicks, ['first', 'first']);
+        return true;
+    }, {crashOnError: false, timeout: 1000});
 
     await closePage(page);
 }

--- a/tests/selftest_clickXPath.js
+++ b/tests/selftest_clickXPath.js
@@ -11,23 +11,25 @@ async function run(config) {
         <button id="first">click me</button>
         <div id="second"></div>
         <script>
+            window.clicks = [];
             ["first", "second"].forEach(id => {
                 const el = document.getElementById(id);
-                el.addEventListener("click", e => registerClick(e.target.id));
+                el.addEventListener("click", e => window.clicks.push(e.target.id));
             })
         </script>
     `);
 
+    const getClicks = async () => page.evaluate(() => window.clicks);
     assert.rejects(clickXPath(page, '//foo', { timeout: 1 }));
-    assert.deepStrictEqual(clicks, []);
+    assert.deepStrictEqual(await getClicks(), []);
 
     assert.rejects(clickXPath(page, '//foo', { timeout: 1, message: 'blabla' }), {
         message: 'blabla'
     });
-    assert.deepStrictEqual(clicks, []);
+    assert.deepStrictEqual(await getClicks(), []);
 
     await clickXPath(page, '//button');
-    assert.deepStrictEqual(clicks, ['first']);
+    assert.deepStrictEqual(await getClicks(), ['first']);
 
     // Option: assertSuccess
     let success = false;

--- a/tests/selftest_click_layer.js
+++ b/tests/selftest_click_layer.js
@@ -1,0 +1,86 @@
+const assert = require('assert').strict;
+const {clickSelector, newPage, clickXPath, clickNestedText} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+
+    await page.setContent(`<!DOCTYPE html>
+        <html>
+        <head>
+        <style>
+            body {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+            }
+
+            .overlay {
+                position: absolute;
+                z-index: 100;
+                top: 2rem;
+                left: 2rem;
+                right: 2rem;
+                bottom: 2rem;
+                background: rgba(255, 0, 0, 0.5);
+            }
+        </style>
+        </head>
+        <body>
+            <div class="overlay"></div>
+            <button>click</button>
+            <script>
+                window.overlayClicks = 0;
+                window.buttonClicks = 0;
+
+                const btn = document.querySelector('button');
+                btn.appendChild(document.createTextNode(' me'));
+                btn.addEventListener('click', () => {
+                    window.buttonClicks++;
+                });
+
+                const overlay = document.querySelector('.overlay');
+                overlay.addEventListener('click', () => {
+                    window.overlayClicks++;
+                });
+            </script>
+        </body>
+        </html>
+    `);
+
+    const getClicks = async () => page.evaluate(() => {
+        return { overlay: window.overlayClicks, button: window.buttonClicks };
+    });
+
+    // All following assertions check that the overlay div that is positioned
+    // above the button intercepts all click events, so that none are triggered
+    // on the button.
+
+    await clickSelector(page, 'button', {timeout: 1000});
+    let clicks = await getClicks();
+    assert.equal(clicks.button, 0);
+    assert.equal(clicks.overlay, 1);
+
+    // Click element
+    await clickXPath(page, '//button', {timeout: 1000});
+    clicks = await getClicks();
+    assert.equal(clicks.button, 0);
+    assert.equal(clicks.overlay, 2);
+
+    // Click text node
+    await clickXPath(page, '//button/text()[2]', {timeout: 1000});
+    clicks = await getClicks();
+    assert.equal(clicks.button, 0);
+    assert.equal(clicks.overlay, 3);
+
+    // Click text node
+    await clickNestedText(page, 'click me', {timeout: 1000});
+    clicks = await getClicks();
+    assert.equal(clicks.button, 0);
+    assert.equal(clicks.overlay, 4);
+}
+
+module.exports = {
+    description: 'Simulates clicks via a mouse like a user would',
+    run,
+};


### PR DESCRIPTION
This PR addresses an error where it was possible to click on visible elements, despite them being hidden behind another. Calling `.click()` directly on the DOM node doesn't check for that, but puppeteer's `Mouse` module does.

In the following example taken out of the test in this PR we can see that a red box is positioned directly above the button we intend to click. A real user won't be able to click this button because the box captures the click event. Before this PR pentf allowed that, even though `visible: true` was set.

<img width="296" alt="Screenshot 2021-01-22 at 16 07 41" src="https://user-images.githubusercontent.com/1062408/105507833-f694de80-5ccb-11eb-8f94-984ec02702a0.png">