### PR TITLE
Visualize user interactions on the page (clicks)

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ The keys are up to you; for example you probably want to have a main entry point
 --extensions [EXTENSION_DIR [EXTENSION_DIR ...]]
                       Load unpacked browser extensions
 --forward-console     Forward browser console logs
+--show-interactions   Visually show on the page where a user interaction took place (clicks, taps,...)
 -d, --debug           Shorthand for "--keep-open --devtools-preserve --forward-console"
 --default-timeout MS  Default timeout value for various browser functions (default: 30s)
 ```

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -13,7 +13,7 @@ const tmp = require('tmp-promise');
 const {performance} = require('perf_hooks');
 const mkdirpCb = require('mkdirp');
 
-const {assertAsyncEventually} = require('./assert_utils');
+const {assertAsyncEventually, assertEventually} = require('./assert_utils');
 const {forwardBrowserConsole} = require('./browser_console');
 const {wait, remove, ignoreError} = require('./utils');
 const {timeoutPromise} = require('./promise_utils');
@@ -206,8 +206,15 @@ async function newPage(config, chrome_args=[]) {
     if (config._browser_pages) {
         config._browser_pages.push(page);
 
-        page.on('popup', popup => {
+        page.on('popup', async popup => {
             config._browser_pages.push(popup);
+            popup.on('domcontentloaded', async () => {
+                await installInteractions(popup);
+            });
+
+            popup.on('framenavigated', async (frame) => {
+                await installInteractions(frame);
+            });
         });
     }
 
@@ -242,7 +249,109 @@ async function newPage(config, chrome_args=[]) {
         });
     }
 
+    if (config.show_interactions) {
+        withInteractions(page, 'setContent');
+        page.on('domcontentloaded', async () => {
+            await installInteractions(page);
+        });
+        page.on('framenavigated', async (frame) => {
+            await installInteractions(frame);
+        });
+    }
+
     return page;
+}
+
+/**
+ * @param {import('puppeteer').Page} page
+ * @param {K extends keyof import('puppeteer').Page} prop
+ */
+function withInteractions(page, prop) {
+    const original = page[prop];
+    page[prop] = async (...args) => {
+        const res = await original.apply(page, args);
+        await installInteractions(page);
+        return res;
+    };
+}
+
+/**
+ * Inject a box into the page that shows last user interaction like where the
+ * last click occured on the page.
+ * @param {import('puppeteer').Page | import('puppeteer').Frame} page
+ */
+async function installInteractions(page) {
+    await assertEventually(
+        async () => {
+            return await page.evaluate(() => {
+                /**
+                 * @param {MouseEvent} e
+                 */
+                function handleEvent(e) {
+                    let x = e.pageX;
+                    let y = e.pageY;
+
+                    // Account for offset of the current frame if we are inside an iframe
+                    let win = window;
+                    let parentWin = null;
+                    while (win !== window.top) {
+                        parentWin = win.parent;
+
+                        const iframe = Array.from(
+                            parentWin.document.querySelectorAll('iframe')
+                        ).find(f => f.contentWindow === win);
+                        if (iframe) {
+                            const iframeRect = iframe.getBoundingClientRect();
+                            x += iframeRect.x;
+                            y += iframeRect.y;
+                            break;
+                        }
+                    }
+
+                    // At this point we're dealing with an embedded iframe. Move
+                    // the parent cursor's pointer to the correct position
+                    let el = window.top.document.querySelector('#pentf-mouse-pointer');
+                    if (el === null) {
+                        el = window.top.document.createElement('div');
+                        el.id = 'pentf-mouse-pointer';
+                        el.innerHTML = `<svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="-4 -4 54 54"
+                        >
+                            <path
+                                d="M1 0v46.3l8.5-9 5 9.8L26.8 41l-5.2-10h12.7z"
+                                fill="#E149E6"
+                                stroke-width="5"
+                                stroke="#fff"
+                            />
+                        </svg>`;
+                        el.style.cssText = `
+                            pointer-events: none;
+                            position: absolute;
+                            top: 0;
+                            z-index: 10000;
+                            left: 0;
+                            width: 24px;
+                            height: 24px;
+                            margin: -2px 0 -2px 0;
+                            padding: 0;
+                        `;
+
+                        window.top.document.body.appendChild(el);
+                    }
+
+                    el.style.left = x + 'px';
+                    el.style.top = y + 'px';
+                }
+
+                document.addEventListener('mousedown', handleEvent, true);
+                document.addEventListener('click', handleEvent, true);
+                document.addEventListener('mouseup', handleEvent, true);
+                return true;
+            });
+        },
+        {crashOnError: false}
+    );
 }
 
 /**

--- a/src/config.js
+++ b/src/config.js
@@ -286,6 +286,10 @@ function parseArgs(options, raw_args) {
         help: 'Forward browser console logs',
         action: 'storeTrue',
     });
+    puppeteer_group.addArgument(['--show-interactions'], {
+        help: 'Visually show on the page where a user interaction took place (clicks, taps,...)',
+        action: 'storeTrue',
+    });
     puppeteer_group.addArgument(['-d', '--debug'], {
         help: 'Shorthand for "--keep-open --devtools-preserve --forward-console"',
         action: 'storeTrue',
@@ -447,6 +451,7 @@ function parseArgs(options, raw_args) {
         args.devtools_preserve = true;
         args.keep_open = true;
         args.forward_console = true;
+        args.show_interactions = true;
     }
     if (args.keep_open) {
         args.headless = false;
@@ -494,7 +499,7 @@ async function readConfigFile(configDir, env, moduleType) {
 }
 
 /**
- * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm"}} Config
+ * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm", show_interactions?: boolean}} Config
  */
 
 /**

--- a/tests/selftest_interactions.js
+++ b/tests/selftest_interactions.js
@@ -1,0 +1,41 @@
+const assert = require('assert').strict;
+const {clickSelector, newPage} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage({...config, show_interactions: true});
+
+    await page.setContent(`<!DOCTYPE html>
+        <html>
+        <head>
+        <style>
+            body {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+            }
+        </style>
+        </head>
+        <body>
+            <button>click</button>
+        </body>
+        </html>
+    `);
+
+    await clickSelector(page, 'button', {timeout: 1000});
+
+    const pos = await page.evaluate(() => {
+        const el = document.querySelector('#pentf-mouse-pointer');
+        return {
+            left: +el.style.left.replace('px', ''),
+            top: +el.style.top.replace('px', '') };
+    });
+
+    assert(pos.left > 100, 'Mouse left position was 0');
+    assert(pos.top > 100, 'Mouse top position was 0');
+}
+
+module.exports = {
+    description: 'Show user interactions on the page',
+    run,
+};

--- a/tests/selftest_interactions_iframe.js
+++ b/tests/selftest_interactions_iframe.js
@@ -1,0 +1,92 @@
+const assert = require('assert').strict;
+const {clickSelector, newPage, interceptRequest} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage({...config, show_interactions: true});
+    await interceptRequest(page, req => {
+        if (req.url().endsWith('pentf.dev/')) {
+            return req.respond({
+                content: 'text/html',
+                body: `<!DOCTYPE html>
+                    <html>
+                    <head>
+                    <style>
+                        iframe {
+                            margin-top: 4rem;
+                        }
+                    </style>
+                    </head>
+                    <body>
+                        <iframe width="640" height="480" src="http://pentf.dev/iframe.html" />
+                    </body>
+                    </html>
+                `,
+            });
+        } else if (req.url().endsWith('/iframe.html')) {
+            return req.respond({
+                content: 'text/html',
+                body: `<!DOCTYPE html>
+                    <html>
+                    <head>
+                    <style>
+                        .wrapper {
+                            height: 150px;
+                            overflow: scroll;
+                        }
+
+                        .inner {
+                            display: flex;
+                            justify-content: center;
+                            align-items: center;
+                            height: 400px;
+                            position: relative;
+                        }
+                    </style>
+                    </head>
+                    <body>
+                        <div class="wrapper">
+                            <div class="inner">
+                                <div class="overlay"></div>
+                                <button>click</button>
+                            </div>
+                        </div>
+                    </body>
+                    </html>
+                `,
+            });
+        }
+    });
+
+    await page.goto('http://pentf.dev');
+
+    const waitForIframe = async () => {
+        const iframe = page.frames().find(f => page.mainFrame() !== f && f.url().includes('pentf.dev'));
+        await iframe.waitForSelector('button');
+        return iframe;
+    };
+
+    const iframe = await waitForIframe();
+
+    await clickSelector(iframe, 'button', {timeout: 1000});
+
+    const pos = await page.evaluate(() => {
+        const el = document.querySelector('#pentf-mouse-pointer');
+        return {
+            left: +el.style.left.replace('px', ''),
+            top: +el.style.top.replace('px', '') };
+    });
+
+    const iframePos = await page.evaluate(() => {
+        const el = document.querySelector('iframe');
+        const rect = el.getBoundingClientRect();
+        return { x: rect.x, y: rect.y };
+    });
+
+    assert(pos.left > iframePos.x, 'Mouse left position was 0');
+    assert(pos.top > iframePos.y, 'Mouse top position was 0');
+}
+
+module.exports = {
+    description: 'Show user interactions on the page',
+    run,
+};


### PR DESCRIPTION
One frequent issue with e2e testing SPAs is that we can't sometimes be sure if an element was clicked. Because there is no visual hint, users would often assume that their selector is wrong, even though it 
was correct.

This PR shows visually which element was clicked to solve that. It can be enabled via the `--show-interactions` command line flag that's automatically enabled when passing `--debug`.

<img width="127" alt="Screenshot 2021-01-25 at 18 11 50" src="https://user-images.githubusercontent.com/1062408/105747137-aecabd00-5f40-11eb-8b2d-148f2e0aeb03.png">
