### PR TITLE
Add support for comparing screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ results*.html
 results*.md
 results*.json
 screenshots
+snapshots
 doc/
 dist/
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -671,6 +671,24 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
       "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
     },
+    "@types/pixelmatch": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@types/pixelmatch/-/pixelmatch-5.2.2.tgz",
+      "integrity": "sha512-ndpfW/H8+SAiI3wt+f8DlHGgB7OeBdgFgBJ6v/1l3SpJ0MCn9wtXFb4mUccMujN5S4DMmAh7MVy1O3WcXrHUKw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/pngjs": {
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/@types/pngjs/-/pngjs-3.4.2.tgz",
+      "integrity": "sha512-LJVPDraJ5YFEnMHnzxTN4psdWz1M61MtaAAWPn3qnDk5fvs7BAmmQ9pd3KPlrdrvozMyne4ktanD4pg0L7x1Pw==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
     "@types/puppeteer": {
       "version": "5.4.0",
       "resolved": "https://registry.npmjs.org/@types/puppeteer/-/puppeteer-5.4.0.tgz",
@@ -3490,6 +3508,21 @@
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
       "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
     },
+    "pixelmatch": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/pixelmatch/-/pixelmatch-5.2.1.tgz",
+      "integrity": "sha512-WjcAdYSnKrrdDdqTcVEY7aB7UhhwjYQKYhHiBXdJef0MOaQeYpUdQ+iVyBLa5YBKS8MPVPPMX7rpOByISLpeEQ==",
+      "requires": {
+        "pngjs": "^4.0.1"
+      },
+      "dependencies": {
+        "pngjs": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-4.0.1.tgz",
+          "integrity": "sha512-rf5+2/ioHeQxR6IxuYNYGFytUyG3lma/WW1nsmjeHlWwtb2aByla6dkVc8pmJ9nplzkTA0q2xx7mMWrOTqT4Gg=="
+        }
+      }
+    },
     "pkg-dir": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -3498,6 +3531,11 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "pngjs": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-6.0.0.tgz",
+      "integrity": "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="
     },
     "posix-character-classes": {
       "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -112,6 +112,8 @@
     "minimatch": "^3.0.4",
     "mkdirp": "^0.5.1",
     "node-fetch": "^2.3.0",
+    "pixelmatch": "^5.2.1",
+    "pngjs": "^6.0.0",
     "stream-buffers": "^3.0.2",
     "tmp-promise": "^2.0.2",
     "tough-cookie": "^4.0.0"
@@ -120,6 +122,8 @@
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.1",
     "@types/diff": "^4.0.2",
+    "@types/pixelmatch": "^5.2.2",
+    "@types/pngjs": "^3.4.2",
     "@types/tmp": "^0.2.0",
     "deep-equal": "^1.0.1",
     "eslint": "^7.0.0",

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -1432,14 +1432,14 @@ async function getSelectOptions(page, select) {
 async function takeScreenshot(config, page, fileName, selector) {
     await mkdirp(config.screenshot_directory);
     const file = path.join(config.screenshot_directory, fileName);
-    return await _takeScreenshot(page, { file, selector });
+    return await _takeScreenshot(page, { file, selector, fullPage: true });
 }
 
 /**
  * @param {import('puppeteer').Page} page
- * @param {{ file?: string, selector?: string }} [options]
+ * @param {{ file?: string, selector?: string, fullPage?: boolean }} [options]
  */
-async function _takeScreenshot(page, { file, selector } = {}) {
+async function _takeScreenshot(page, { file, selector, fullPage } = {}) {
     const viewport = page.viewport();
     let img;
     if (selector) {
@@ -1452,7 +1452,7 @@ async function _takeScreenshot(page, { file, selector } = {}) {
         img = await page.screenshot({
             path: file,
             type: 'png',
-            fullPage: true,
+            fullPage,
         });
     }
 
@@ -1551,9 +1551,9 @@ async function assertAccessibility(config, page) {
  * @param {import('./internal').TaskConfig} config
  * @param {import('puppeteer').Page} page
  * @param {string} name
- * @param {{ threshold?: number, selector?: string, ...pxl: import('pixelmatch').PixelmatchOptions }} [options]
+ * @param {{ threshold?: number, selector?: string, fullPage?: boolean } & import('pixelmatch').PixelmatchOptions} [options]
  */
-async function assertSnapshot(config, page, name, {threshold = 0.2, selector, ...pxl} = {}) {
+async function assertSnapshot(config, page, name, {threshold = 0.2, selector, fullPage = true, ...pxl} = {}) {
     await mkdirp(config.snapshot_directory);
     const target = path.join(config.snapshot_directory, `${config._taskName}_${name}-expected.png`);
 
@@ -1573,9 +1573,9 @@ async function assertSnapshot(config, page, name, {threshold = 0.2, selector, ..
     // We have never seen this snapshot before, take a new one
     // or we want to update existing snapshots
     if (expected === null || config.update_snapshots) {
-        await _takeScreenshot(page, {file: target, selector});
+        await _takeScreenshot(page, {file: target, selector, fullPage});
     } else {
-        const actualBuf = await _takeScreenshot(page, {selector});
+        const actualBuf = await _takeScreenshot(page, {selector, fullPage});
         const actual = await PNG.sync.read(actualBuf);
 
         // We don't need to look further if the dimensions don't even match

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -12,6 +12,8 @@ const {promisify} = require('util');
 const tmp = require('tmp-promise');
 const {performance} = require('perf_hooks');
 const mkdirpCb = require('mkdirp');
+const { PNG } = require('pngjs');
+const pixelmatch = require('pixelmatch');
 
 const {assertAsyncEventually} = require('./assert_utils');
 const {forwardBrowserConsole} = require('./browser_console');
@@ -1429,19 +1431,26 @@ async function getSelectOptions(page, select) {
  */
 async function takeScreenshot(config, page, fileName, selector) {
     await mkdirp(config.screenshot_directory);
-    const fn = path.join(config.screenshot_directory, fileName);
+    const file = path.join(config.screenshot_directory, fileName);
+    return await _takeScreenshot(page, { file, selector });
+}
 
+/**
+ * @param {import('puppeteer').Page} page
+ * @param {{ file?: string, selector?: string }} [options]
+ */
+async function _takeScreenshot(page, { file, selector } = {}) {
     const viewport = page.viewport();
     let img;
     if (selector) {
         const el = await page.waitForSelector(selector);
         img = await el.screenshot({
-            path: fn,
+            path: file,
             type: 'png',
         });
     } else {
         img = await page.screenshot({
-            path: fn,
+            path: file,
             type: 'png',
             fullPage: true,
         });
@@ -1533,6 +1542,88 @@ async function assertAccessibility(config, page) {
         const err = new Error(`There were ${errors.length} accessibility violations on ${url}`);
         err.accessibilityErrors = errors;
         throw err;
+    }
+}
+
+/**
+ * Take a screenshot and compare it against an existing one. Any differences between
+ * the two will be highlighted.
+ * @param {import('./internal').TaskConfig} config
+ * @param {import('puppeteer').Page} page
+ * @param {string} name
+ * @param {{ threshold?: number, selector?: string, ...pxl: import('pixelmatch').PixelmatchOptions }} [options]
+ */
+async function assertSnapshot(config, page, name, {threshold = 0.2, selector, ...pxl} = {}) {
+    await mkdirp(config.snapshot_directory);
+    const target = path.join(config.snapshot_directory, `${config._taskName}_${name}-expected.png`);
+
+    /** @type {import('pngjs').PNGWithMetadata | null} */
+    let expected = null;
+    /** @type {Buffer | null} */
+    let expectedBuf = null;
+    try {
+        expectedBuf = await fs.promises.readFile(target);
+        expected = PNG.sync.read(expectedBuf);
+    } catch (e) {
+        if (!e.message.includes('ENOENT')) {
+            throw e;
+        }
+    }
+
+    // We have never seen this snapshot before, take a new one
+    // or we want to update existing snapshots
+    if (expected === null || config.update_snapshots) {
+        await _takeScreenshot(page, {file: target, selector});
+    } else {
+        const actualBuf = await _takeScreenshot(page, {selector});
+        const actual = await PNG.sync.read(actualBuf);
+
+        // We don't need to look further if the dimensions don't even match
+        if (actual.width !== expected.width || actual.height !== expected.height) {
+            const expectedSize = `${expected.height}x${expected.width}px`;
+            const actualSize = `${actual.height}x${actual.width}px`;
+            throw new Error(
+                `Snapshot size differs. Expected ${expectedSize} but got ${actualSize}`
+            );
+        }
+
+        const diff = new PNG({width: expected.width, height: expected.height});
+        const differenceCount = pixelmatch(
+            expected.data,
+            actual.data,
+            diff.data,
+            expected.width,
+            expected.height,
+            {threshold, diffColor: [255, 70, 230], ...pxl}
+        );
+
+        if (differenceCount > 0) {
+            // Write image with highlighted differences to disk
+            const buf = PNG.sync.write(diff);
+            const diffFile = path.join(
+                config.screenshot_directory,
+                `${config._taskName}_${name}-diff.png`
+            );
+            await fs.promises.writeFile(diffFile, buf);
+
+            // Attach diff image to task so that it shows up in PDFs
+            config._snapshots.push(buf);
+
+            // Write actual image to disk too (for visual reference)
+            const actualFile = path.join(
+                config.screenshot_directory,
+                `${config._taskName}_${name}-actual.png`
+            );
+            await fs.promises.writeFile(actualFile, actualBuf);
+            // Write expected image to disk too (for visual reference)
+            const expectedFile = path.join(
+                config.screenshot_directory,
+                `${config._taskName}_${name}-expected.png`
+            );
+            await fs.promises.writeFile(expectedFile, expectedBuf);
+
+            throw new Error(`Snapshot failed, there were ${differenceCount} differences, see ${diffFile}`);
+        }
     }
 }
 
@@ -1675,6 +1766,7 @@ module.exports = {
     assertNotSelector,
     assertNotTestId,
     assertNotXPath,
+    assertSnapshot,
     assertValue,
     clickNestedText,
     clickSelector,

--- a/src/config.js
+++ b/src/config.js
@@ -258,6 +258,17 @@ function parseArgs(options, raw_args) {
         defaultValue: defaultScreenshotDir,
         help: `Directory to write screenshots to (default: ${process.env.PENTF_GENERIC_HELP ? './screenshots' : '%(defaultValue)s'})`,
     });
+    const defaultSnapshotDir = path.join(
+        options.rootDir ? options.rootDir : process.cwd(), 'snapshots');
+    puppeteer_group.addArgument(['--snapshot-directory'], {
+        metavar: 'DIR',
+        defaultValue: defaultSnapshotDir,
+        help: `Directory to write snapshots to (default: ${process.env.PENTF_GENERIC_HELP ? './snapshots' : '%(defaultValue)s'})`,
+    });
+    puppeteer_group.addArgument(['-u', '--update-snapshots'], {
+        help: 'Update existing snapshots on mismatch',
+        action: 'storeTrue',
+    });
     puppeteer_group.addArgument(['-s', '--slow-mo'], {
         metavar: 'MS',
         type: 'int',
@@ -499,7 +510,7 @@ async function readConfigFile(configDir, env, moduleType) {
 }
 
 /**
- * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm", show_interactions?: boolean}} Config
+ * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, breadcrumbs?: boolean, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm", show_interactions?: boolean, snapshot_directory: string, update_snapshots?: boolean}} Config
  */
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -44,6 +44,7 @@ export interface TaskConfig extends Config {
     _taskName: string;
     _taskGroup: string;
     error: Error | null;
+    _snapshots: Buffer[];
     accessibilityErrors: A11yResult[];
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -40,6 +40,7 @@ async function run_task(config, state, task) {
         _testName: task.tc.name,
         _taskName: task.name,
         _taskGroup: task.group,
+        _snapshots: [],
         start: task.start,
         accessibilityErrors: [],
         error: null,
@@ -126,7 +127,7 @@ async function run_task(config, state, task) {
 
                 // Collect all screenshots first before throwing
                 // potential errors.
-                task.error_screenshots = [];
+                task.error_screenshots = [...task_config._snapshots];
                 let error = null;
                 for (const imgOrErr of screenshots) {
                     if (Buffer.isBuffer(imgOrErr)) {

--- a/tests/selftest_snapshot.js
+++ b/tests/selftest_snapshot.js
@@ -1,0 +1,33 @@
+const assert = require('assert').strict;
+const path = require('path');
+const mkdirpCb = require('mkdirp');
+const rimrafCb = require('rimraf');
+const {promisify} = require('util');
+const mkdirp = promisify(mkdirpCb);
+const rimraf = promisify(rimrafCb);
+
+const {newPage, assertSnapshot} = require('../src/browser_utils');
+
+async function run(config) {
+    const dir = path.join(__dirname, 'snapshot_test', 'snapshots');
+    config = {...config, snapshot_directory: dir};
+
+    // Clean before running tests
+    await rimraf(dir);
+    await mkdirp(dir);
+
+    const page = await newPage(config);
+    await page.setContent('<h1 style="font-size: 64px">Hello world!</h1>');
+    await assertSnapshot(config, page, '1');
+
+    await page.setContent('<h1 style="font-size: 32px">Hello world!</h1>');
+    await assert.rejects(assertSnapshot(config, page, '1'));
+
+    await page.setContent('<h1 style="font-size: 64px">Hello world!</h1>');
+    await assertSnapshot(config, page, '1');
+}
+
+module.exports = {
+    description: 'Compare snapshots',
+    run,
+};

--- a/tests/selftest_snapshot_update.js
+++ b/tests/selftest_snapshot_update.js
@@ -1,0 +1,31 @@
+const path = require('path');
+const mkdirpCb = require('mkdirp');
+const rimrafCb = require('rimraf');
+const {promisify} = require('util');
+const mkdirp = promisify(mkdirpCb);
+const rimraf = promisify(rimrafCb);
+
+const {newPage, assertSnapshot} = require('../src/browser_utils');
+
+async function run(config) {
+    const dir = path.join(__dirname, 'snapshot_update_test', 'snapshots');
+    config = {...config, snapshot_directory: dir, update_snapshots: true};
+
+    // Clean before running tests
+    await rimraf(dir);
+    await mkdirp(dir);
+
+    const page = await newPage(config);
+    await page.setContent('<h1 style="font-size: 64px">Hello world!</h1>');
+    await assertSnapshot(config, page, '1');
+
+    await page.setContent('<h1 style="font-size: 32px">Hello world!</h1>');
+
+    // Update existing snapshot
+    await assertSnapshot(config, page, '1');
+}
+
+module.exports = {
+    description: 'Update existing snapshots',
+    run,
+};

--- a/tests/selftest_snapshot_viewport.js
+++ b/tests/selftest_snapshot_viewport.js
@@ -1,0 +1,39 @@
+const assert = require('assert').strict;
+const path = require('path');
+const fs = require('fs');
+const { PNG } = require('pngjs');
+const mkdirpCb = require('mkdirp');
+const rimrafCb = require('rimraf');
+const {promisify} = require('util');
+const mkdirp = promisify(mkdirpCb);
+const rimraf = promisify(rimrafCb);
+
+const {newPage, assertSnapshot} = require('../src/browser_utils');
+
+async function run(config) {
+    const dir = path.join(__dirname, 'snapshot_test_viewport', 'snapshots');
+    config = {...config, snapshot_directory: dir};
+
+    // Clean before running tests
+    await rimraf(dir);
+    await mkdirp(dir);
+
+    const page = await newPage(config);
+    await page.setContent('<h1 style="font-size: 64px">Hello world!</h1>');
+    await page.setViewport({
+        height: 180,
+        width: 320
+    });
+    await assertSnapshot(config, page, '1', { fullPage: false });
+
+    const buf = await fs.promises.readFile(path.join(dir, `${config._taskName}_1-expected.png`));
+    const img = PNG.sync.read(buf);
+
+    assert.equal(img.width, 320);
+    assert.equal(img.height, 180);
+}
+
+module.exports = {
+    description: 'Compare snapshots with a specific viewport',
+    run,
+};


### PR DESCRIPTION
This PR adds an `assertSnapshot` function that can be used to compare previous screenshots to current ones. When there is a difference between the two it will mark differences visually like below. Existing snapshots are always updated if there is no expected one found or if `-u, --update-snapshots` is passed via the CLI. By default snapshots are stored in `./snapshots` as I assumed that the reference images should be committed into git.

Replaces PR #28 .

Actual:

![actual](https://user-images.githubusercontent.com/1062408/106670863-e0c9c800-65ad-11eb-9ad6-736bedcb3a7a.png)

Expected:

![expected](https://user-images.githubusercontent.com/1062408/106670876-e6271280-65ad-11eb-87e7-92cf84cec63a.png)

Diff:

![Artboard](https://user-images.githubusercontent.com/1062408/106670681-aa8c4880-65ad-11eb-8382-ead3a907ad32.png)