### PR TITLE
Pass through task resources for custom validation

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -11,6 +11,7 @@ export type TestCase = {
     fileName: string;
     name: string;
     group: string;
+    resources?: string[]
     run: (config: TaskConfig) => Promise<void> | void;
     skip?: (config: TaskConfig) => Promise<boolean> | boolean;
     expectedToFail?: string | boolean;
@@ -30,6 +31,7 @@ export interface Task {
     breadcrumb: Error | null;
     skipReason?: boolean;
     error_screenshots: Buffer[];
+    resources: string[];
     expectedToFail?: boolean | string | ((config: import('./config').Config) => boolean);
     accessibilityErrors: A11yResult[];
 }
@@ -44,6 +46,7 @@ export interface TaskConfig extends Config {
     _taskName: string;
     _taskGroup: string;
     error: Error | null;
+    resources: string[];
     _snapshots: Buffer[];
     accessibilityErrors: A11yResult[];
 }

--- a/src/runner.js
+++ b/src/runner.js
@@ -34,6 +34,7 @@ async function run_task(config, state, task) {
     /** @type {import('./internal').TaskConfig} */
     const task_config = {
         ...config,
+        resources: Object.freeze(task.resources),
         _teardown_hooks: [],
         _browser_pages: [],
         _breadcrumb: null,


### PR DESCRIPTION
This allows user functions to validate if a resource was locked by the runner before attempting to use it in the test.

Something like:

```js
function resetTonie(config, tonieId) {
  if (!config.resources.some(r => r === tonieId)) {
    throw new Error(`Forgot to specify Tonie id ${tonieId} in test resources');
  }
  
  // ...
}
```