### PR TITLE
Add createUserPrrofileDir to create temporary user profiles

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -290,6 +290,15 @@ async function newPage(config, chrome_args=[]) {
 }
 
 /**
+ * Add a callback to execute during the teardown phase of the test case.
+ * @param {import('./internal').TaskConfig} config
+ * @param {import('./internal').TeardownHook} callback
+ */
+function onTeardown(config, callback) {
+    config._teardown_hooks.push(callback);
+}
+
+/**
  * @param {import('puppeteer').Page} page
  * @param {K extends keyof import('puppeteer').Page} prop
  */
@@ -1832,6 +1841,7 @@ module.exports = {
     html2pdf,
     interceptRequest,
     newPage,
+    onTeardown,
     restoreTimeouts,
     setLanguage,
     speedupTimeouts,

--- a/src/runner.js
+++ b/src/runner.js
@@ -5,6 +5,8 @@ const {performance} = require('perf_hooks');
 const kolorist = require('kolorist');
 
 const browser_utils = require('./browser_utils');
+// Makes the babel commonjs to esm much easier
+const { onTeardown } = require('./browser_utils');
 const email = require('./email');
 const external_locking = require('./external_locking');
 const locking = require('./locking');
@@ -677,6 +679,6 @@ async function run(config, testCases) {
 }
 
 module.exports = {
-    onTeardown: browser_utils.onTeardown,
+    onTeardown,
     run,
 };

--- a/src/runner.js
+++ b/src/runner.js
@@ -16,15 +16,6 @@ const { getCPUCount } = require('./config');
 const { shouldShowError } = require('./output');
 
 /**
- * Add a callback to execute during the teardown phase of the test case.
- * @param {import('./internal').TaskConfig} config
- * @param {import('./internal').TeardownHook} callback
- */
-function onTeardown(config, callback) {
-    config._teardown_hooks.push(callback);
-}
-
-/**
  * @param {import('./config').Config} config
  * @param {import('./internal').RunnerState} state
  * @param {import('./internal').Task} task
@@ -686,6 +677,6 @@ async function run(config, testCases) {
 }
 
 module.exports = {
-    onTeardown,
+    onTeardown: browser_utils.onTeardown,
     run,
 };

--- a/tests/selftest_user_data_dir.js
+++ b/tests/selftest_user_data_dir.js
@@ -1,0 +1,43 @@
+const assert = require('assert').strict;
+
+const {closePage, newPage, createUserProfileDir} = require('../src/browser_utils');
+
+async function run(config) {
+    const dir = await createUserProfileDir(config);
+
+    const page = await newPage(config, ['--user-data-dir=' + dir]);
+    await page.goto('https://example.com');
+
+    let value = await page.evaluate(() => {
+        return window.localStorage.getItem('foo');
+    });
+    assert.equal(value, null);
+
+    await page.evaluate(() => {
+        window.localStorage.setItem('foo', 'foobar');
+    });
+    await closePage(page);
+
+    const page2 = await newPage(config, ['--user-data-dir=' + dir]);
+    await page2.goto('https://example.com');
+    value = await page2.evaluate(() => {
+        return window.localStorage.getItem('foo');
+    });
+    assert.equal(value, 'foobar');
+
+    // Create 2nd dir
+    const dir2 = await createUserProfileDir(config);
+    const page3 = await newPage(config, ['--user-data-dir=' + dir2]);
+    await page3.goto('https://example.com');
+    value = await page3.evaluate(() => {
+        return window.localStorage.getItem('foo');
+    });
+
+    // Check if value doesn't leak from previous user data dir
+    assert.equal(value, null);
+}
+
+module.exports = {
+    description: 'Create temporary user data dir',
+    run,
+};


### PR DESCRIPTION
For some tests we need to verify that values in `LocalStorage` persist across browser sessions. To test that we need a shared user profile, because `puppeteer.launch()` creates a unique one on each call. 