### PR TITLE
Lower default concurrency to the amount of CPU cores

### DIFF
--- a/src/config.js
+++ b/src/config.js
@@ -313,7 +313,7 @@ function parseArgs(options, raw_args) {
     });
 
     const runner_group = parser.addArgumentGroup({title: 'Test runner'});
-    const concurrency_default = '4+cpus';
+    const concurrency_default = 'cpus';
     runner_group.addArgument(['-C', '--concurrency'], {
         metavar: 'COUNT',
         help: (


### PR DESCRIPTION
On several users the default setting was too high leading to lots of test timeouts caused by scarce CPU resources.

~The new default is number of CPU cores minus one for the main thread. This is the same value used in [jest](https://github.com/facebook/jest/blob/196e5731c8985dbdb6ce7d224c9dd4348f356009/packages/jest-config/src/getMaxWorkers.ts#L25)~