### PR TITLE
Extract page resizing into re-usable function resizePage()

### DIFF
--- a/tests/selftest_resizePage.js
+++ b/tests/selftest_resizePage.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+const {newPage, resizePage} = require('../src/browser_utils');
+const {assertEventually} = require('../src/assert_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+
+    const size = await page.evaluate(() => {
+        return {width: window.innerWidth, height: window.innerHeight};
+    });
+    assert.deepEqual(size, {width: 800, height: 600});
+
+    await resizePage(config, page, {width: 1280, height: 900});
+
+    await assertEventually(async () => {
+        return await page.evaluate(() => {
+            return window.innerWidth === 1280 && window.innerHeight === 900;
+        });
+    });
+}
+
+module.exports = {
+    run,
+    description: 'Resize window to ensure page matches specified dimensions',
+};


### PR DESCRIPTION
This allows users to resize the window so that the page matches the specified dimensions. Contrary to `page.setViewport()` this doesn't rely on emulation mode in non-headless environments and thereby allows the user to resize the page by dragging the window corners.

Fixes #347 .