### PR TITLE
README: improve tests-glob example

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following script to your `package.json` with the `--tests-glob` paramete
 {
     "name": "my-package",
     "scripts": {
-        "test": "pentf --tests-glob test/**/*.test.js",
+        "test": "pentf --tests-glob tests/**/*.js",
     }
 }
 ```


### PR DESCRIPTION
the .test sub-extension is redundant and not mentioned in the example below. And the example below uses a tests folder, so keep the naming consistent here.