### PR TITLE
Don't inject interaction ui in trusted types context

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -382,7 +382,18 @@ function withInteractions(page, prop) {
  * @param {import('puppeteer').Page | import('puppeteer').Frame} page
  */
 async function installInteractions(page) {
+    const config = getBrowser(page)._pentf_config;
     try {
+        // Skip injecting into html when trusted page is enabled to prevent
+        // noisy console output, that confused users.
+        const isTrustedPage = await page.evaluate(() => {
+            return document.head && document.head.querySelector('meta[content*="trusted-types"   ]') !==  null;
+        });
+        if (isTrustedPage) {
+            output.logVerbose(config, 'Cannot install pentf interaction ui overlays into page with trusted types. Skipping...');
+            return;
+        }
+
         await page.evaluate(() => {
             /**
              * @param {MouseEvent} e

--- a/tests/selftest_interactions_trusted.js
+++ b/tests/selftest_interactions_trusted.js
@@ -1,0 +1,40 @@
+const assert = require('assert').strict;
+const {clickSelector, newPage} = require('../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage({...config, show_interactions: true});
+
+    const content = `<!DOCTYPE html>
+        <html>
+        <head>
+        <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'; trusted-types;"></meta>
+        <style>
+            body {
+                display: flex;
+                justify-content: center;
+                align-items: center;
+                height: 100vh;
+            }
+        </style>
+        </head>
+        <body>
+            <button>click</button>
+        </body>
+        </html>
+    `;
+
+    await page.setContent(content);
+
+    await clickSelector(page, 'button', {timeout: 1000});
+
+    const isPresent = await page.evaluate(() => {
+        return document.querySelector('#pentf-mouse-pointer') !== null;
+    });
+
+    assert(!isPresent, 'Interaction ui was injected, despite TrustedHTML warning');
+}
+
+module.exports = {
+    description: 'Skip injecting user interactions on the page when TrustedHTML is enabled',
+    run,
+};


### PR DESCRIPTION
So far those errors only pop up when trying to inject stuff into the native browser warning pages that warn for insecure form submission. In that case skip injecting the interaction UI. This PR prevents noisy console errors like this:

<img width="497" alt="Screenshot 2021-02-24 at 17 16 09" src="https://user-images.githubusercontent.com/1062408/109030412-1309a980-76c4-11eb-86cd-b4f83e94003b.png">
