### PR TITLE
Workaround broken executable path on M1 macbooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1578,9 +1578,9 @@
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
     },
     "devtools-protocol": {
-      "version": "0.0.818844",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.818844.tgz",
-      "integrity": "sha512-AD1hi7iVJ8OD0aMLQU5VK0XH9LDlA1+BcPIgrAxPfaibx2DbWucuyOhc4oyQCbnvDDO68nN6/LcKfqTP343Jjg==",
+      "version": "0.0.854822",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.854822.tgz",
+      "integrity": "sha512-xd4D8kHQtB0KtWW0c9xBZD5LVtm9chkMOfs/3Yn01RhT/sFIsVtzTtypfKoFfWBaL+7xCYLxjOLkhwPXaX/Kcg==",
       "dev": true
     },
     "diff": {
@@ -3828,23 +3828,44 @@
       }
     },
     "puppeteer": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-5.5.0.tgz",
-      "integrity": "sha512-OM8ZvTXAhfgFA7wBIIGlPQzvyEETzDjeRa4mZRCRHxYL+GNH5WAuYUQdja3rpWZvkX/JKqmuVgbsxDNsDFjMEg==",
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-8.0.0.tgz",
+      "integrity": "sha512-D0RzSWlepeWkxPPdK3xhTcefj8rjah1791GE82Pdjsri49sy11ci/JQsAO8K2NRukqvwEtcI+ImP5F4ZiMvtIQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.0",
-        "devtools-protocol": "0.0.818844",
+        "devtools-protocol": "0.0.854822",
         "extract-zip": "^2.0.0",
-        "https-proxy-agent": "^4.0.0",
+        "https-proxy-agent": "^5.0.0",
         "node-fetch": "^2.6.1",
         "pkg-dir": "^4.2.0",
         "progress": "^2.0.1",
-        "proxy-from-env": "^1.0.0",
+        "proxy-from-env": "^1.1.0",
         "rimraf": "^3.0.2",
         "tar-fs": "^2.0.0",
         "unbzip2-stream": "^1.3.3",
         "ws": "^7.2.3"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+          "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+          "dev": true,
+          "requires": {
+            "debug": "4"
+          }
+        },
+        "https-proxy-agent": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.0.tgz",
+          "integrity": "sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==",
+          "dev": true,
+          "requires": {
+            "agent-base": "6",
+            "debug": "4"
+          }
+        }
       }
     },
     "ramda": {
@@ -5102,9 +5123,9 @@
       }
     },
     "ws": {
-      "version": "7.4.2",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.2.tgz",
-      "integrity": "sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==",
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.3.tgz",
+      "integrity": "sha512-hr6vCR76GsossIRsr8OLR9acVVm1jyfEWvhbNjtgPOrfvAlKzvyeg/P6r8RuDjRyrcQoPQT7K0DGEPc7Ae6jzA==",
       "dev": true
     },
     "xdg-basedir": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,7 @@
     "eslint": "^7.0.0",
     "nodemon": "^2.0.4",
     "prettier": "^2.0.5",
-    "puppeteer": "^5.5.0",
+    "puppeteer": "^8.0.0",
     "rimraf": "^3.0.2",
     "ts-node": "^9.0.0",
     "typedoc": "^0.17.4",

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -46,6 +46,7 @@ let tmp_home;
  */
 async function newPage(config, chrome_args=[]) {
     addBreadcrumb(config, 'enter newPage()');
+    /** @type {import('puppeteer')} */
     let puppeteer;
     try {
         if(config.puppeteer_firefox) {
@@ -127,7 +128,12 @@ async function newPage(config, chrome_args=[]) {
     }
 
     /** @type {import('puppeteer').Browser} */
-    const browser = await puppeteer.launch(params);
+    const browser = await puppeteer.launch({
+        ...params,
+        // Workaround until official support for Apple's M1 chip lands in puppeteer:
+        // Puppeteer for some reason ignores the environment variable on arm64 systems
+        executablePath: process.env.PUPPETEER_EXECUTABLE_PATH
+    });
     const page = (await browser.pages())[0];
 
     if (config.devtools_preserve) {


### PR DESCRIPTION
For some reason Puppeteer completely ignores the environment variable
 on arm64 systems