### PR TITLE
Fix binary node not found in child_process

### DIFF
--- a/tests/selftest_async_skip.js
+++ b/tests/selftest_async_skip.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'skip_tests', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_cli.js
+++ b/tests/selftest_cli.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, '..', 'bin', 'cli.js');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--tests-glob', 'tests/skip_tests/*.js', '--no-pdf'],
             (err, stdout, stderr) => {
                 if (err) reject(err);

--- a/tests/selftest_console_navigation.js
+++ b/tests/selftest_console_navigation.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'console_navigation', 'run');
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--forward-console'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_error_summary.js
+++ b/tests/selftest_error_summary.js
@@ -8,7 +8,7 @@ async function run() {
         const sub_run = path.join(__dirname, 'error_output', 'run');
         const {stdout} = await new Promise((resolve, reject) => {
             child_process.execFile(
-                'node',
+                process.execPath,
                 [sub_run, '--exit-zero', '--no-screenshots', '--no-color'],
                 { cwd: path.dirname(sub_run) },
                 (err, stdout, stderr) => {
@@ -26,7 +26,7 @@ async function run() {
         const sub_run = path.join(__dirname, 'error_output', 'run');
         const {stdout} = await new Promise((resolve, reject) => {
             child_process.execFile(
-                'node',
+                process.execPath,
                 [sub_run, '--exit-zero', '--no-screenshots', '--no-color', '-v'],
                 { cwd: path.dirname(sub_run) },
                 (err, stdout, stderr) => {

--- a/tests/selftest_esm.js
+++ b/tests/selftest_esm.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'esm_tests', 'run');
     const {stdout, stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_flaky_reprint_errors.js
+++ b/tests/selftest_flaky_reprint_errors.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'flaky_tests', 'run');
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-colors', '--no-screenshots', '--repeat-flaky', '3', '--ci', '-f', 'flaky'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_flaky_result.js
+++ b/tests/selftest_flaky_result.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'flaky_tests', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-colors', '--no-screenshots', '--repeat-flaky', '3', '--ci'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_flaky_result_repeat.js
+++ b/tests/selftest_flaky_result_repeat.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'flaky_tests', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-colors', '--no-screenshots',  '--repeat', '3', '--repeat-flaky', '3', '--quiet'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_glob.js
+++ b/tests/selftest_glob.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'glob_tests', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--tests-glob', '*.spec.js'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_list_locks.js
+++ b/tests/selftest_list_locks.js
@@ -8,7 +8,7 @@ async function run() {
     try {
         await new Promise((resolve, reject) => {
             child_process.execFile(
-                'node',
+                process.execPath,
                 [sub_run, '--exit-zero', '--no-screenshots', '--ci', '--list-locks', '--quiet'],
                 {cwd: path.dirname(sub_run)},
                 (err, stdout, stderr) => {

--- a/tests/selftest_log_file.js
+++ b/tests/selftest_log_file.js
@@ -20,7 +20,7 @@ async function run() {
 
     await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--log-file', logFile],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_maxeventlisteners.js
+++ b/tests/selftest_maxeventlisteners.js
@@ -6,7 +6,7 @@ const path = require('path');
 async function run() {
     // Run in subprocess so that handle exhaustion does not affect this process
     const sub_run = path.join(__dirname, 'maxEventListeners_tests', 'run');
-    const proc = child_process.spawn('node', [sub_run, '--exit-zero', '--no-screenshots', '-C', '4+cpus'], {});
+    const proc = child_process.spawn(process.execPath, [sub_run, '--exit-zero', '--no-screenshots', '-C', '4+cpus'], {});
     let stderr = '';
     await new Promise(resolve => {
         proc.stderr.on('data', s => {

--- a/tests/selftest_no_clear_line_status.js
+++ b/tests/selftest_no_clear_line_status.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'no_clear_line', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--ci', '-C', '5', '--quiet'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_no_test.js
+++ b/tests/selftest_no_test.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'no_tests', 'run');
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_options.js
+++ b/tests/selftest_options.js
@@ -7,7 +7,7 @@ async function run() {
 
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--ci', '--print-config', '--quiet'],
             {cwd: path.dirname(sub_run)},
             (err, stdout, stderr) => {

--- a/tests/selftest_popup_screenshot.js
+++ b/tests/selftest_popup_screenshot.js
@@ -19,7 +19,7 @@ async function run() {
     const sub_run = path.join(fixture, 'run');
     await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--json', '-v'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_result.js
+++ b/tests/selftest_result.js
@@ -22,7 +22,7 @@ async function run() {
 
     await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [path.join(fixture, 'run'), '--exit-zero', '--html', '--json', '--markdown', '--pdf'],
             { cwd: fixture },
             (err, stdout, stderr) => {

--- a/tests/selftest_suite.js
+++ b/tests/selftest_suite.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'suite', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-f', 'suite$'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_suite_nested.js
+++ b/tests/selftest_suite_nested.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'suite', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-f', 'suite_nested$'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_suite_nested_only.js
+++ b/tests/selftest_suite_nested_only.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'suite', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-f', 'suite_nested_only$'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_suite_only.js
+++ b/tests/selftest_suite_only.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'suite', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-f', '^only'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_suite_skip.js
+++ b/tests/selftest_suite_skip.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'suite', 'run');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-f', '^skip'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_teardown_task_error.js
+++ b/tests/selftest_teardown_task_error.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'teardown_task_error', 'run');
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '-v'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_timeout.js
+++ b/tests/selftest_timeout.js
@@ -7,7 +7,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'timeout_tests', 'run');
     const {stdout, stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--exit-zero', '--no-screenshots', '--timeout', '100'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_ts_node.js
+++ b/tests/selftest_ts_node.js
@@ -6,7 +6,7 @@ async function run() {
     const script = path.join(__dirname, '..', 'bin', 'cli.js');
     const {stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             ['-r', 'ts-node/register', script, '--exit-zero', '--no-screenshots', '--tests-glob', 'tests/ts_node/*.ts', '--no-pdf'],
             (err, stdout, stderr) => {
                 if (err) reject(err);

--- a/tests/selftest_version_pentf.js
+++ b/tests/selftest_version_pentf.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'version_pentf', 'run');
     const {stdout} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run, '--version'],
             { cwd: path.dirname(sub_run) },
             (err, stdout, stderr) => {

--- a/tests/selftest_version_pentf_ci.js
+++ b/tests/selftest_version_pentf_ci.js
@@ -6,7 +6,7 @@ async function run() {
     const sub_run = path.join(__dirname, 'version_ci_tests', 'run');
     const {stdout, stderr} = await new Promise((resolve, reject) => {
         child_process.execFile(
-            'node',
+            process.execPath,
             [sub_run],
             { cwd: path.dirname(sub_run), env: { ...process.env, CI: 'true' } },
             (err, stdout, stderr) => {

--- a/tests/selftest_watch.js
+++ b/tests/selftest_watch.js
@@ -6,7 +6,7 @@ const { onTeardown } = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '-f', 'foo', '--ci', '--no-colors', '--no-pdf']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '-f', 'foo', '--ci', '--no-colors', '--no-pdf']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_clear.js
+++ b/tests/selftest_watch_clear.js
@@ -5,7 +5,7 @@ const {onTeardown} = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests_no_writes', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
+    const child = child_process.spawn(process.execPath,[sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_current.js
+++ b/tests/selftest_watch_current.js
@@ -6,7 +6,7 @@ const { onTeardown } = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_enter.js
+++ b/tests/selftest_watch_enter.js
@@ -5,7 +5,7 @@ const {onTeardown} = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests_no_writes', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_files.js
+++ b/tests/selftest_watch_files.js
@@ -6,7 +6,7 @@ const { onTeardown } = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--watch-files', 'no-test.js', '--tests-glob', 'test.js', '--ci', '--no-colors', '--no-pdf']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '--watch-files', 'no-test.js', '--tests-glob', 'test.js', '--ci', '--no-colors', '--no-pdf']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_pattern.js
+++ b/tests/selftest_watch_pattern.js
@@ -38,7 +38,7 @@ function createTyper(getOutput, clearOutput) {
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests_no_writes', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf']);
     onTeardown(config, () => child.kill());
 
     let out = [];

--- a/tests/selftest_watch_quit.js
+++ b/tests/selftest_watch_quit.js
@@ -6,7 +6,7 @@ const {onTeardown} = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests_no_writes', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '--ci', '--no-colors', '--no-pdf', '-f', 'foo']);
     onTeardown(config, () => child.kill());
 
     const out = [];

--- a/tests/selftest_watch_slow.js
+++ b/tests/selftest_watch_slow.js
@@ -6,7 +6,7 @@ const { onTeardown } = require('../src/runner');
 
 async function run(config) {
     const sub_run = path.join(__dirname, 'watch_tests', 'run');
-    const child = child_process.spawn('node', [sub_run, '--watch', '-f', 'slow', '--ci', '--no-colors', '--no-pdf']);
+    const child = child_process.spawn(process.execPath, [sub_run, '--watch', '-f', 'slow', '--ci', '--no-colors', '--no-pdf']);
     onTeardown(config, () => child.kill());
     const out = [];
 


### PR DESCRIPTION
This happens because child processes are not executed in the same shell the main process was started in.