### PR TITLE
Fix types for package exports not found.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -40,6 +40,7 @@
         "@babel/cli": "^7.10.5",
         "@babel/core": "^7.11.1",
         "@types/diff": "^4.0.2",
+        "@types/node": "^14.14.35",
         "@types/pixelmatch": "^5.2.2",
         "@types/pngjs": "^3.4.2",
         "@types/sharp": "^0.27.1",
@@ -806,9 +807,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "node_modules/@types/node": {
-      "version": "13.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
     "node_modules/@types/pixelmatch": {
       "version": "5.2.2",
@@ -6977,9 +6978,9 @@
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA=="
     },
     "@types/node": {
-      "version": "13.9.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-13.9.1.tgz",
-      "integrity": "sha512-E6M6N0blf/jiZx8Q3nb0vNaswQeEyn0XlupO+xN6DtJ6r6IT4nXrTry7zhIfYvFCl3/8Cu6WIysmUBKiqV0bqQ=="
+      "version": "14.14.35",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.35.tgz",
+      "integrity": "sha512-Lt+wj8NVPx0zUmUwumiVXapmaLUcAk3yPuHCFVXras9k5VT9TdhJqKqGVUQCD60OTMCl0qxJ57OiTL0Mic3Iag=="
     },
     "@types/pixelmatch": {
       "version": "5.2.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.4.4",
   "description": "parallel end-to-end test framework",
   "main": "src/index.js",
-  "types": "dist/types/__index.d.ts",
+  "types": "dist/types/index.d.ts",
   "directories": {
     "test": "tests"
   },
@@ -123,6 +123,7 @@
     "@babel/cli": "^7.10.5",
     "@babel/core": "^7.11.1",
     "@types/diff": "^4.0.2",
+    "@types/node": "^14.14.35",
     "@types/pixelmatch": "^5.2.2",
     "@types/pngjs": "^3.4.2",
     "@types/sharp": "^0.27.1",

--- a/patch-types.js
+++ b/patch-types.js
@@ -1,41 +1,13 @@
 const fs = require('fs');
 const path = require('path');
 
-function addModule(name, content) {
-    const type = content
-        .replace(/declare function/g, 'function')
-        .split('\n').map(x => '    ' + x).join('\n');
+// TypeScript doesn't understand package exports, so we need
+// to pretend that every entry is a top-level one. See:
+// https://github.com/microsoft/TypeScript/issues/33079
+const typesDir = path.join(__dirname, 'dist', 'types');
+const files = fs.readdirSync(typesDir)
+    .map(file => path.join(typesDir, file));
 
-    return `\ndeclare module "${name}" {\n${type}\n}\n`;
+for (const file of files) {
+    fs.copyFileSync(file, path.join(__dirname, path.basename(file)));
 }
-
-const entries = Object.keys(require('./package.json').exports)
-    .filter(x => x !== './package.json' && x !== './');
-
-let main = '';
-
-const moduleReg = /(?:from\s['"]([A-Za-z0-9_\-./]+)['"]|import\(['"]([A-Za-z0-9_\-./]+)['"]\))/g;
-
-for (const entry of entries) {
-    const name = entry === '.' ? 'index' : entry.slice(2);
-    const type = fs.readFileSync(path.join(__dirname, 'dist', 'types', name + '.d.ts'), 'utf-8');
-    const mod = name === 'index' ? 'pentf' : 'pentf/' + name;
-
-    main += addModule(mod, type)
-        // Rewrite module imports inside pentf to reference each other.
-        // TS doesn't allow relative imports in an ambient TS file.
-        .replace(moduleReg, (match, staticImport, dynamicImport) => {
-            let source = staticImport || dynamicImport;
-            if (!source.startsWith('./') || source === './internal') {
-                return match;
-            }
-
-            source = `pentf/${source.slice(2)}`;
-
-            return staticImport ? `from "${source}"` : `import("${source}")`;
-        });
-}
-
-const target = path.join(__dirname, 'dist', 'types', '__index.d.ts');
-fs.writeFileSync(target, main);
-


### PR DESCRIPTION
Newer TypeScript versions have trouble resolving package entries via an ambient declaration file. They seem to always traverse the directory directly instead and disregard what's defined in package.json, except for the main entry.

The only solution that works is to store types in the root folder again.

See: https://github.com/microsoft/TypeScript/issues/33079