### PR TITLE
Add waitFor and waitForPass as shorthand for assertEventually

### DIFF
--- a/src/assert_utils.js
+++ b/src/assert_utils.js
@@ -176,6 +176,24 @@ async function assertEventually(testfunc,
 }
 
 /**
+ * Wait until a function returns a result that is truthy
+ * @param {() => any} testfunc
+ * @param {{timeout?: number, checkEvery?: number}} options
+ */
+async function waitFor(testfunc, options) {
+    await assertEventually(testfunc, { crashOnError: true, ...options });
+}
+
+/**
+ * Wait until a function doesn't throw anymore.
+ * @param {() => any} testfunc
+ * @param {{timeout?: number, checkEvery?: number}} options
+ */
+async function waitForPass(testfunc, options) {
+    await assertEventually(testfunc, { crashOnError: false, ...options });
+}
+
+/**
  * Assert that an asynchronously evaluated condition is eventually true.
  *
  * @param {() => Promise<any>} testfunc The async test function. Must return `true` to signal success.
@@ -295,4 +313,6 @@ module.exports = {
     assertNotIncludes,
     assertNumeric,
     lazyAssert,
+    waitFor,
+    waitForPass,
 };

--- a/tests/selftest_waitFor.js
+++ b/tests/selftest_waitFor.js
@@ -1,0 +1,36 @@
+const assert = require('assert').strict;
+const {waitFor, waitForPass} = require('../src/assert_utils');
+
+async function run() {
+    // waitFor
+    await assert.rejects(waitFor(() => false, {timeout: 10, checkEvery: 1, message: 'Never changed'}), {
+        message: 'Never changed (waited 10ms)',
+    });
+
+    await assert.rejects(waitFor(() => false, {timeout: 10, checkEvery: 1}), {
+        message: 'assertEventually failed (waited 10ms)',
+    });
+
+    await assert.rejects(waitFor(() => {throw new Error('crash');}), {
+        message: 'crash',
+    });
+
+    // waitForPass
+    await assert.doesNotReject(waitForPass(() => false, {timeout: 10, checkEvery: 1, message: 'Never changed'}), {
+        message: 'Never changed (waited 10ms)',
+    });
+
+    let counter = 0;
+    await waitForPass(() => {
+        counter++;
+        if (counter < 3) {
+            throw new Error('crash');
+        }
+    }, {checkEvery: 1});
+    assert.strictEqual(counter, 3);
+}
+
+module.exports = {
+    description: 'Wait that a condition passes',
+    run,
+};


### PR DESCRIPTION
Saw that devs struggle with the purpose of assertEventually. We noticed that it's commonly used for 2 use cases and it's better to split them up.