### PR TITLE
Improve locking awareness

### DIFF
--- a/src/locking.js
+++ b/src/locking.js
@@ -85,9 +85,8 @@ async function acquire(config, state, task) {
                 return false;
             }
         } catch(e) {
-            if (config.locking_verbose || config.log_file) {
-                output.logVerbose(config, `[exlocking] Failed to acquire locks for ${task.id}: ${e.stack}`);
-            }
+            // Something is wrong with the locking server
+            output.color(config, 'red', `[exlocking] Failed to acquire locks for ${task.id}. Is the lockserver up and running?\n\n${e.stack}`);
             return false;
         }
     }

--- a/src/output.js
+++ b/src/output.js
@@ -83,13 +83,17 @@ function status(config, state) {
     const terminal_width = STATUS_STREAM.getWindowSize ? STATUS_STREAM.getWindowSize()[0] : Infinity;
     let status_str;
     for (let running_show = running.length;running_show >= 0;running_show--) {
-        const running_str = (
+        let running_str = (
             running.slice(0, running_show).map(task => task.name).join(' ')
             + (running_show < running.length ? '  +' + (running.length - running_show) : '')
         );
+        if (running_str.length > 0) {
+            running_str = ` (${running_str})`;
+        }
+
         status_str = (
             `${done.length}/${tasks.length - skipped.length} done, ` +
-            `${success_str}${failed_str}${expected_fail_str}${running.length} running (${running_str})`);
+            `${success_str}${failed_str}${expected_fail_str}${running.length} running${running_str}`);
 
         if (status_str.length < terminal_width) {
             break; // Fits!

--- a/src/output.js
+++ b/src/output.js
@@ -69,11 +69,10 @@ function status(config, state) {
     last_state = state;
 
     const testResults = Array.from(state.resultByTaskGroup.values());
-    const {errored, expectedToFail, skipped, success} = getResults(config, testResults);
+    const {errored, expectedToFail, skipped, success, running} = getResults(config, testResults);
     const {tasks} = state;
 
     const done = tasks.filter(t => t.status === 'error' || t.status === 'success');
-    const running = tasks.filter(t => t.status === 'running');
 
     const failed_str = errored.length > 0 ? color(config, 'red', `${errored.length} failed, `) : '';
     const expected_fail_str = expectedToFail.length > 0 ? `${expectedToFail.length} failed as expected, ` : '';

--- a/src/results.js
+++ b/src/results.js
@@ -20,6 +20,7 @@ function getResults(config, results) {
     const expectedToFailButPassed = !expectNothing && results.filter(
         t => t.expectedToFail && t.status === 'success');
     const todo = results.filter(t => t.status === 'todo');
+    const running = results.filter(t => t.status === 'running');
 
     return {
         success,
@@ -29,6 +30,7 @@ function getResults(config, results) {
         expectedToFail,
         expectedToFailButPassed,
         todo,
+        running,
     };
 }
 

--- a/src/runner.js
+++ b/src/runner.js
@@ -414,6 +414,12 @@ async function parallel_run(config, state) {
                 if (config.verbose || config.locking_verbose) {
                     const waitingTasksStr = state.tasks.filter(t => t.status === 'todo').map(t => t.id).join(',');
                     output.log(config, `[runner] Still waiting for locks on tasks ${waitingTasksStr}`);
+                } else if (state.running.length < config.concurrency) {
+                    const waitingTasksStr = state.tasks
+                        .filter(t => t.status === 'todo')
+                        .map(t => output.color(config, 'cyan', t.id))
+                        .join(',');
+                    output.log(config, `Waiting for locks on ${waitingTasksStr}`);
                 }
                 continue;
             }


### PR DESCRIPTION
- Don't swallow errors thrown by the locking server
- Print waiting for locks message when running < concurrency
- Fix `0 running ()` -> `0 running`

Fixes #387, #388