### PR TITLE
Print timeouts in human readable time instead of ms only

### DIFF
--- a/src/assert_utils.js
+++ b/src/assert_utils.js
@@ -9,6 +9,7 @@
 const assert = require('assert').strict;
 
 const {wait, ignoreError} = require('./utils');
+const output = require('./output');
 
 /**
 * Assert that a value is a Number or BigInt.
@@ -177,11 +178,11 @@ async function assertEventually(testfunc,
     }
 
     if (caughtError !== null) {
-        caughtError.message += ` (waited ${timeout}ms)`;
+        caughtError.message += ` (waited ${output.formatTime(timeout)}ms)`;
         throw caughtError;
     }
 
-    throw new Error(`${message} (waited ${timeout}ms)`);
+    throw new Error(`${message} (waited ${output.formatTime(timeout)})`);
 }
 
 /**
@@ -233,7 +234,7 @@ async function assertAsyncEventually(testfunc,
 
         await wait(checkEvery);
     }
-    throw new Error(`${message} (waited ${timeout}ms)`);
+    throw new Error(`${message} (waited ${output.formatTime(timeout)})`);
 }
 
 /**
@@ -249,7 +250,7 @@ async function assertAlways(testfunc, {message='assertAlways failed', timeout=10
     for (let remaining = timeout;remaining > 0;remaining -= checkEvery) {
         const res = testfunc();
         if (!res) {
-            throw new Error(`${message} (after ${timeout - remaining}ms)`);
+            throw new Error(`${message} (after ${output.formatTime(timeout - remaining)})`);
         }
 
         await wait(checkEvery);

--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -597,13 +597,13 @@ async function waitForSelector(page, selector, {message=undefined, timeout=getDe
         if (foundCount > 0) {
             const suffix = foundCount > 1 ? `. There are ${foundCount - 1} more elements matching the same selector on the page. Maybe the selector needs to be more specific?`:'';
             const err = new Error(
-                `Element matching  ${selector}  did not become visible within ${timeout}ms${suffix}` +
+                `Element matching  ${selector}  did not become visible within ${output.formatTime(timeout)}${suffix}` +
                     (message ? `. ${message}` : '')
             );
             throw await enhanceError(config, page, err);
         } else {
             const err = new Error(
-                `Failed to find element matching  ${selector}  within ${timeout}ms` +
+                `Failed to find element matching  ${selector}  within ${output.formatTime(timeout)}` +
                     (message ? `. ${message}` : '')
             );
             throw await enhanceError(config, page, err);
@@ -689,7 +689,7 @@ async function waitForText(page, text, {timeout=getDefaultTimeout(page), extraMe
     addBreadcrumb(config, `enter waitForText(${text})`);
     checkText(text);
     const extraMessageRepr = extraMessage ? ` (${extraMessage})` : '';
-    const err = new Error(`Unable to find text ${JSON.stringify(text)} after ${timeout}ms${extraMessageRepr}`);
+    const err = new Error(`Unable to find text ${JSON.stringify(text)} after ${output.formatTime(timeout)}${extraMessageRepr}`);
 
     const xpath = `//text()[contains(., ${escapeXPathText(text)})]`;
     try {
@@ -726,7 +726,7 @@ async function waitForTestId(page, testId, {extraMessage=undefined, timeout=getD
     addBreadcrumb(config, `enter waitForTestId(${testId})`);
 
     const err = new Error(
-        `Failed to find ${visible ? 'visible ' : ''}element with data-testid "${testId}" within ${timeout}ms` +
+        `Failed to find ${visible ? 'visible ' : ''}element with data-testid "${testId}" within ${output.formatTime(timeout)}` +
         (extraMessage ? `. ${extraMessage}` : ''));
 
     const qs = `*[data-testid="${testId}"]`;
@@ -985,7 +985,7 @@ async function clickSelector(page, selector, {timeout=getDefaultTimeout(page), c
             }
 
             if (!message) {
-                message = `Unable to find ${visible ? 'visible ' : ''}element ${selector} after ${timeout}ms`;
+                message = `Unable to find ${visible ? 'visible ' : ''}element ${selector} after ${output.formatTime(timeout)}`;
             }
             throw await enhanceError(config, page, new Error(message));
         }
@@ -1163,7 +1163,7 @@ async function clickXPath(page, xpath, {timeout=getDefaultTimeout(page), checkEv
             }
 
             if (!message) {
-                message = `Unable to find XPath ${xpath} after ${timeout}ms`;
+                message = `Unable to find XPath ${xpath} after ${output.formatTime(timeout)}`;
             }
             throw await enhanceError(config, page, new Error(message));
         }
@@ -1202,7 +1202,7 @@ async function clickText(page, text, {timeout=getDefaultTimeout(page), checkEver
         timeout,
         checkEvery,
         retryUntil: retryUntil || assertSuccess,
-        message: `Unable to find text ${JSON.stringify(text)} after ${timeout}ms${extraMessageRepr}`,
+        message: `Unable to find text ${JSON.stringify(text)} after ${output.formatTime(timeout)}${extraMessageRepr}`,
     });
     addBreadcrumb(config, `exit clickText(${text})`);
     return res;
@@ -1366,7 +1366,7 @@ async function clickNestedText(page, textOrRegExp, {timeout=getDefaultTimeout(pa
             }
 
             const extraMessageRepr = extraMessage ? ` (${extraMessage})` : '';
-            throw await enhanceError(config, page, new Error(`Unable to find${visible ? ' visible' : ''} text "${textOrRegExp}" after ${timeout}ms${extraMessageRepr}`));
+            throw await enhanceError(config, page, new Error(`Unable to find${visible ? ' visible' : ''} text "${textOrRegExp}" after ${output.formatTime(timeout)}${extraMessageRepr}`));
         }
         await wait(Math.min(remainingTimeout, checkEvery));
         remainingTimeout -= checkEvery;
@@ -1393,7 +1393,7 @@ async function clickTestId(page, testId, {extraMessage=undefined, timeout=getDef
 
     const xpath = `//*[@data-testid="${testId}"]`;
     const extraMessageRepr = extraMessage ? `. ${extraMessage}` : '';
-    const message = `Failed to find${visible ? ' visible' : ''} element with data-testid "${testId}" within ${timeout}ms${extraMessageRepr}`;
+    const message = `Failed to find${visible ? ' visible' : ''} element with data-testid "${testId}" within ${output.formatTime(timeout)}${extraMessageRepr}`;
     const res = await clickXPath(page, xpath, {timeout, message, visible, retryUntil: retryUntil || assertSuccess});
     addBreadcrumb(config, `exit clickTestId(${testId})`);
     return res;

--- a/src/output.js
+++ b/src/output.js
@@ -117,10 +117,10 @@ function status(config, state) {
 
 /**
  * Convert a time to a human readable string
- * @param {*} config
  * @param {number} duration Time in ms
  */
-function formatDuration(config, duration) {
+function formatTime(duration) {
+    let milliseconds = Math.floor(duration % 1000);
     let seconds = Math.floor((duration / 1000) % 60);
     let minutes = Math.floor((duration / (1000 * 60)) % 60);
     let hours = Math.floor(duration / (1000 * 60 * 60));
@@ -133,7 +133,24 @@ function formatDuration(config, duration) {
         str += `${minutes}min `;
     }
 
-    str += `${seconds}s`;
+    if (seconds > 0) {
+        str += `${seconds}s `;
+    }
+
+    if ((milliseconds > 0 || str === '')) {
+        str += `${milliseconds}ms`;
+    }
+
+    return str.trim();
+}
+
+/**
+ * Convert a time to a human readable string with colors
+ * @param {*} config
+ * @param {number} duration Time in ms
+ */
+function formatDuration(config, duration) {
+    const str = formatTime(duration);
 
     let timeColor = 'dim';
     if (duration > 60000) timeColor = 'red';
@@ -744,7 +761,9 @@ module.exports = {
     detailedStatus,
     finish,
     formatError,
+    formatDuration,
     formatA11yError,
+    formatTime,
     valueRepr,
     log,
     logTaskError,

--- a/src/promise_utils.js
+++ b/src/promise_utils.js
@@ -114,7 +114,7 @@ async function timeoutPromise(config, promise, {timeout=10000, message=undefined
             promise,
             new Promise((resolve, reject) => setTimeout(() => {
                 let wholeMessage = (
-                    `Promise did not finish within ${timeout}ms` + (message ? '. ' + message : ''));
+                    `Promise did not finish within ${output.formatTime(timeout)}` + (message ? '. ' + message : ''));
                 if (warning) {
                     if (resolved) {
                         return; // Main promise done already


### PR DESCRIPTION
It's much easier for mere mortals read `12s 50ms` compared to `12050ms`