### PR TITLE
runner: Show full stack if teardown crashes

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -204,7 +204,7 @@ async function run_task(config, state, task) {
             } catch(e) {
                 output.log(
                     config,
-                    `INTERNAL ERROR: failed to run teardown for #${task.id} (${task.name}): ${e}`
+                    `INTERNAL ERROR: failed to run teardown for #${task.id} (${task.name}): ${e.stack}`
                 );
             }
         } else if (config.watch) {


### PR DESCRIPTION
Sometimes, the test teardown fails. In these cases, show the full stack to aid debugging.

Previously:
```
INTERNAL ERROR: failed to run teardown for #toniebox_claim_tonie (toniebox_claim_tonie): TypeError: encodeURIComponent(...) is not a function
```

With this PR:

```
INTERNAL ERROR: failed to run teardown for #toniebox_claim_tonie (toniebox_claim_tonie): TypeError: encodeURIComponent(...) is not a function
    at _headless_sso_login (/home/phihag/e2etests/lib/sso_utils.js:550:9)
    at sso_api_delete_account (/home/phihag/e2etests/lib/sso_utils.js:594:33)
    at auth_headless_delete_account (/home/phihag/e2etests/lib/auth_utils.js:78:12)
    at /home/phihag/e2etests/lib/auth_utils.js:96:42
    at /home/phihag/e2etests/node_modules/pentf/src/runner.js:198:91
    at Array.map (<anonymous>)
    at run_task (/home/phihag/e2etests/node_modules/pentf/src/runner.js:198:81)
    at runMicrotasks (<anonymous>)
    at processTicksAndRejections (node:internal/process/task_queues:94:5)
    at async run_one (/home/phihag/e2etests/node_modules/pentf/src/runner.js:319:5)

```
