### PR TITLE
Print urls of open pages on test failure

### DIFF
--- a/src/internal.ts
+++ b/src/internal.ts
@@ -29,6 +29,7 @@ export interface Task {
     status: TaskStatus;
     start: number;
     breadcrumb: Error | null;
+    pageUrls: string[];
     skipReason?: boolean;
     error_screenshots: Buffer[];
     resources: string[];
@@ -52,6 +53,7 @@ export interface TaskConfig extends Config {
 }
 
 export interface TaskResult {
+    pageUrls: string[];
     status: TaskStatus;
     duration: number; error_screenshots: Buffer[];
     error_stack?: string;

--- a/src/output.js
+++ b/src/output.js
@@ -684,10 +684,15 @@ async function logTaskError(config, task) {
                 config, `${label} test case ${name} at ${utils.localIso8601()} but section was expected to fail:\n${e.stack}\n`);
         } else {
             const label = color(config, 'inverse-red', 'FAILED');
+            const pageUrlString = task.pageUrls.length
+                ? `  Open pages: ${task.pageUrls.join(', ')}\n`
+                : '';
             log(
                 config,
                 `${label} test case ${name} at ${utils.localIso8601()}:\n` +
-                `${await formatError(config, e)}\n`);
+                pageUrlString
+                + `${await formatError(config, e)}\n`
+            );
 
             // There won't be a useful stack trace if the test timed out.
             // Display collected breadcrumb additionally if there is one.

--- a/src/render.js
+++ b/src/render.js
@@ -309,6 +309,13 @@ function html(results) {
 
                 if (first) first = false;
 
+                if (tr.pageUrls.length) {
+                    const pageUrls = tr.pageUrls
+                        .map(url => `<a href="${escape_html(url)}">${escape_html(url)}</a>`)
+                        .join(', ');
+                    res += `<p class="open_pages">Open pages: <span class="open_pages_list">${pageUrls}</span></p>`;
+                }
+
                 res += (
                     '<div class="error_stack"' + (first ? '' : ' style="margin-top:2em; overflow-wrap: break-word;word-break: break-all;"') + '>' +
                     escape_html(tr.error_stack || 'INTERNAL ERROR: no error stack') +
@@ -428,6 +435,13 @@ td.test_footer {
     height: 7px;
 }
 
+.open_pages {
+    margin-top: 0.5rem;
+    font-size: 70%;
+}
+.open_pages_list {
+    color: #0088ff;
+}
 .description {
     font-size: 80%;
     color: #333;

--- a/src/runner.js
+++ b/src/runner.js
@@ -140,6 +140,9 @@ async function run_task(config, state, task) {
                     `INTERNAL ERROR: failed to take screenshot of #${task.id} (${task.name}): ${e}\n${e.stack}`);
             }
         }
+
+        task.pageUrls = task_config._browser_pages.map(page => page.url());
+
         // Close all browser windows
         if (! config.keep_open && task_config._browser_pages.length > 0) {
             output.logVerbose(
@@ -277,6 +280,7 @@ function update_results(config, state, task) {
     // Append the task result if the task finished
     if (task.status === 'error' || task.status === 'success' || task.status === 'skipped') {
         result.taskResults.push({
+            pageUrls: task.pageUrls,
             status: task.status,
             duration: task.duration, // TODO,
             error_stack: task.error ?
@@ -481,7 +485,7 @@ async function testCases2tasks(config, testCases, resultByTaskGroup) {
 
     const tasks = new Array(testCases.length * repeat);
     await Promise.all(testCases.map(async (tc, position) => {
-        /** @type {Task} */
+        /** @type {import('./internal').Task} */
         const task = {
             tc,
             resources: tc.resources || [],
@@ -490,7 +494,8 @@ async function testCases2tasks(config, testCases, resultByTaskGroup) {
             group: tc.name,
             id: tc.name,
             start: 0,
-            accessibilityErrors: []
+            accessibilityErrors: [],
+            pageUrls: [],
         };
 
         const skipReason = tc.skip && await tc.skip(config);

--- a/tests/breadcrumb/no-page.js
+++ b/tests/breadcrumb/no-page.js
@@ -1,0 +1,8 @@
+async function run() {
+    throw new Error('fail');
+}
+
+module.exports = {
+    description: 'nothing to see here',
+    run,
+};

--- a/tests/breadcrumb/run
+++ b/tests/breadcrumb/run
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+});

--- a/tests/breadcrumb/with-page.js
+++ b/tests/breadcrumb/with-page.js
@@ -1,0 +1,14 @@
+const {newPage} = require('../../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+
+    await page.goto('https://example.com');
+
+    throw new Error('fail');
+}
+
+module.exports = {
+    description: 'Test with page to show url in logs',
+    run,
+};

--- a/tests/selftest_error-page-urls.js
+++ b/tests/selftest_error-page-urls.js
@@ -1,0 +1,38 @@
+const assert = require('assert').strict;
+const child_process = require('child_process');
+const path = require('path');
+
+/**
+ * @param {string} test
+ * @returns {Promise<{stdout: string, stderr: string}>}
+ */
+function runPentf(test) {
+    const sub_run = path.join(__dirname, 'breadcrumb', 'run');
+    return new Promise((resolve, reject) => {
+        child_process.execFile(
+            process.execPath,
+            [sub_run, '--exit-zero', '--no-colors', '--no-screenshots', '--ci', '-f', test],
+            { cwd: path.dirname(sub_run) },
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({stdout, stderr});
+            }
+        );
+    });
+}
+
+async function run() {
+    {
+        const {stdout} = await runPentf('with-page');
+        assert.match(stdout, /Open pages: https:\/\/example.com\//);
+    }
+    {
+        const {stdout} = await runPentf('no-page');
+        assert.doesNotMatch(stdout, /Open pages:/);
+    }
+}
+
+module.exports = {
+    description: 'Print urls of openend pages in error output',
+    run,
+};


### PR DESCRIPTION
Next to the error stack trace we print all opened urls. This makes it easier to understand at which point a test failed when elements are not found.

<img width="314" alt="Screenshot 2021-06-11 at 14 01 07" src="https://user-images.githubusercontent.com/1062408/121683305-7970d700-cabd-11eb-8eee-ba11540cec03.png">


Fixes #405 , #404, #384 .