### PR TITLE
ESM: Add support for transpiling named re-exports

### DIFF
--- a/babel-transform-commonjs-to-esm.js
+++ b/babel-transform-commonjs-to-esm.js
@@ -14,6 +14,8 @@ function moveComments(node, target) {
 /**
  * This babel plugin doesn't aim to support every edge case for CommonJS
  * modules and instead only focuses on the subset we use in this repo.
+ * @param {object} options
+ * @param {import('@babel/core').types} options.types
  */
 module.exports = function cjs2esm({types: t}) {
     return {
@@ -182,6 +184,12 @@ module.exports = function cjs2esm({types: t}) {
                                 moveComments(decl.node, exportNode);
                                 path.node.body[decl.i] = exportNode;
                             }
+                        } else {
+                            path.node.body.push(
+                                t.exportNamedDeclaration(null, [
+                                    t.exportSpecifier(prop.value, prop.key),
+                                ])
+                            );
                         }
                     });
 

--- a/tests/test_esm_transpile.js
+++ b/tests/test_esm_transpile.js
@@ -80,6 +80,19 @@ export { foo };`
 export { foo };`
     );
 
+    await assertTranspile(
+        `
+        function foo() {}
+
+        module.exports = {
+            foo,
+            bar: foo,
+        };
+    `,
+        `export function foo() {}
+export { foo as bar };`
+    );
+
     // Append extension to relative imports
     await assertTranspile(
         `


### PR DESCRIPTION
This PR adds support for transpiling the following pattern for our ESM build of pentf:

```js
function bar() {}

module.exports = {
  foo: bar
}
```