### PR TITLE
Add browser screen recorder

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,14 @@ jobs:
 
       - run: npm ci
 
+      - name: Linux ffmpeg
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt-get install ffmpeg
+
+      - name: macOS ffmpeg
+        if: matrix.os == 'macOS-latest'
+        run: brew install ffmpeg
+
       - name: Linux test parallel
         if: matrix.os == 'ubuntu-latest'
         run: xvfb-run --auto-servernum ./run --ci

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ results*.md
 results*.json
 screenshots
 snapshots
+videos/
 doc/
 dist/
 
@@ -13,3 +14,6 @@ dist/
 
 # Generated types
 /*.d.ts
+
+# macOS
+.DS_Store

--- a/src/config.js
+++ b/src/config.js
@@ -292,6 +292,22 @@ function parseArgs(options, raw_args) {
         help: 'Update existing snapshots on mismatch',
         action: 'storeTrue',
     });
+    puppeteer_group.addArgument(['--video'], {
+        action: 'storeTrue',
+        dest: 'video',
+        help: 'Record videos of browser pages for failed tests',
+    });
+    const defaultVideoDir = path.join(
+        options.rootDir ? options.rootDir : process.cwd(),
+        'videos'
+    );
+    puppeteer_group.addArgument(['--video-directory'], {
+        metavar: 'DIR',
+        defaultValue: defaultVideoDir,
+        help: `Directory to write videos to (default: ${
+            process.env.PENTF_GENERIC_HELP ? './videos' : '%(defaultValue)s'
+        })`,
+    });
     puppeteer_group.addArgument(['-s', '--slow-mo'], {
         metavar: 'MS',
         type: 'int',
@@ -325,7 +341,7 @@ function parseArgs(options, raw_args) {
         action: 'storeTrue',
     });
     puppeteer_group.addArgument(['-d', '--debug'], {
-        help: 'Shorthand for "--keep-open --devtools-preserve --forward-console"',
+        help: 'Shorthand for "--keep-open --devtools-preserve --forward-console --video"',
         action: 'storeTrue',
     });
     puppeteer_group.addArgument(['--default-timeout'], {
@@ -491,6 +507,7 @@ function parseArgs(options, raw_args) {
         args.keep_open = true;
         args.forward_console = true;
         args.show_interactions = true;
+        args.video = true;
     }
     if (args.keep_open) {
         args.headless = false;
@@ -543,7 +560,7 @@ async function readConfigFile(configDir, env, moduleType) {
 }
 
 /**
- * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm", show_interactions?: boolean, snapshot_directory: string, update_snapshots?: boolean}} Config
+ * @typedef {{config_file: string, no_external_locking?: boolean, no_locking?: boolean, locking_verbose?: boolean, external_locking_client?: string, external_locking_url?: string, expect_nothing?: boolean, log_file?: string, log_file_stream?: fs.WriteStream, repeatFlaky: number, concurrency: number, watch: boolean, watch_files?: string, testsGlob: string, moduleType: "commonjs" | "esm", show_interactions?: boolean, snapshot_directory: string, update_snapshots?: boolean, video?: boolean, video_directory: string}} Config
  */
 
 /**

--- a/src/internal.ts
+++ b/src/internal.ts
@@ -42,6 +42,15 @@ export interface Task {
 
 export type TeardownHook = (config: TaskConfig) => Promise<void> | void;
 
+export interface VideoRecorder {
+    start(options: {
+        width: number;
+        height: number;
+        outputFile: string;
+    }): Promise<void>;
+    stop(): Promise<void>;
+}
+
 export interface TaskConfig extends Config {
     _teardown_hooks: TeardownHook[];
     _browser_pages: Page[];
@@ -49,6 +58,8 @@ export interface TaskConfig extends Config {
     _testName: string;
     _taskName: string;
     _taskGroup: string;
+    _video_counter: number;
+    _video_recorder: null | VideoRecorder;
     error: Error | null;
     resources: string[];
     _snapshots: Buffer[];

--- a/src/runner.js
+++ b/src/runner.js
@@ -34,6 +34,8 @@ async function run_task(config, state, task) {
         _testName: task.tc.name,
         _taskName: task.name,
         _taskGroup: task.group,
+        _video_counter: 1,
+        _video_recorder: null,
         _snapshots: [],
         start: task.start,
         accessibilityErrors: [],

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -70,8 +70,8 @@ class VideoRecorder {
         });
 
         this._process.on('error', err => {
-            console.log('Failed to spawn ffmpeg', err);
-            throw err;
+            console.log(err);
+            throw new Error('Failed to spawn "ffmpeg"');
         });
 
         this._session = await this._page.target().createCDPSession();

--- a/src/video-recorder.js
+++ b/src/video-recorder.js
@@ -1,0 +1,172 @@
+const { spawn } = require('child_process');
+const assert = require('assert');
+const path = require('path');
+const fs = require('fs').promises;
+
+/**
+ * Get time without daylight savings or other human concepts.
+ * See https://stackoverflow.com/questions/46964779/monotonically-increasing-time-in-node-js
+ * @returns {number}
+ */
+function monotonicTime() {
+    const [seconds, nanoseconds] = process.hrtime();
+    return seconds * 1000 + Math.trunc(nanoseconds / 1000000);
+}
+
+class VideoRecorder {
+    /**
+     * @param {string} ffmpegPath
+     * @param {import('puppeteer').Page} page
+     */
+    constructor(ffmpegPath, page) {
+        this.ffmpegPath = ffmpegPath;
+        this._process = null;
+        this._page = page;
+        /** @type {{ buffer: Buffer, timestamp: number } | null} */
+        this._lastFrame = null;
+        // Seems to be the maximum value the browser can keep up with.
+        // TODO: should we expose this?
+        this._fps = 25;
+        /** @type {Buffer[]} */
+        this._frameQueue = [];
+
+        // Chrome uses their own timers which don't match ours. Not sure what
+        // format they use. Therefore we keep track of frame times ourselves
+        // and apply the delta to pad gaps.
+        this._hrtime = monotonicTime();
+
+        this._writePromise = Promise.resolve();
+        this._closePromise = Promise.resolve();
+    }
+
+    /**
+     * @param {{ width: number, height: number, outputFile: string }} options
+     */
+    async start(options) {
+        const { width, height, outputFile } = options;
+        assert(width);
+        assert(height);
+        assert(outputFile);
+
+        await fs.mkdir(path.dirname(outputFile), { recursive: true });
+
+        // Taken from:
+        // https://github.com/microsoft/playwright/blob/e7d4d61442f66f4a861f73c6618af39bf5be4c01/src/server/chromium/videoRecorder.ts#L90
+        const ffmpegArgs = `-loglevel error -f image2pipe -c:v mjpeg -i - -y -an -r ${this._fps} -c:v vp8 -qmin 0 -qmax 50 -crf 8 -deadline realtime -b:v 1M -vf pad=${width}:${height}:0:0:gray,crop=${width}:${height}:0:0`;
+
+        this._process = spawn(this.ffmpegPath, [
+            ...ffmpegArgs.split(' '),
+            options.outputFile,
+        ]);
+
+        this._closePromise = new Promise((resolve, reject) => {
+            this._process.on('close', code => {
+                if (code === 1) {
+                    reject(new Error('FFmpeg closed with exit code 1'));
+                } else {
+                    resolve();
+                }
+            });
+        });
+
+        this._process.on('error', err => {
+            console.log('Failed to spawn ffmpeg', err);
+            throw err;
+        });
+
+        this._session = await this._page.target().createCDPSession();
+
+        await this._session.send('Page.startScreencast', {
+            format: 'jpeg',
+            quality: 80,
+            maxWidth: width,
+            maxHeight: height,
+        });
+
+        this._session.on('Page.screencastFrame', this._onFrame.bind(this));
+    }
+
+    /**
+     * @param {{ sessionId: number, data: string,  metadata: { offsetTop: number, pageScaleFactor: number, deviceWidth: number, deviceHeight: number, scrollOffsetX: number, scrollOffsetY: number, timestamp: number }}} frame
+     */
+    async _onFrame(frame) {
+        // Confirm to devtools protocol that we received the message
+        this._session.send('Page.screencastFrameAck', {
+            sessionId: frame.sessionId,
+        });
+
+        const { timestamp } = frame.metadata;
+        const buffer = Buffer.from(frame.data, 'base64');
+
+        await this._writeFrame(buffer, timestamp);
+    }
+
+    /**
+     * Write files to buffer and fill time gaps by repeating the
+     * last frame. This is necessary to satisfy the fps count.
+     * @param {Buffer} buffer
+     * @param {number} timestamp
+     */
+    _writeFrame(buffer, timestamp) {
+        this._hrtime = monotonicTime();
+
+        // The browser will only send frames when something has changed.
+        // Therefore we need to pad the last frame to meet fps
+        // requirements and have the correct video length.
+        if (this._lastFrame !== null) {
+            const delta = timestamp - this._lastFrame.timestamp;
+            const repeat = Math.max(1, Math.round(this._fps * delta));
+
+            for (let i = 0; i < repeat; i++) {
+                this._frameQueue.push(this._lastFrame.buffer);
+            }
+
+            this._writePromise = this._writePromise.then(() =>
+                this._sendFrames()
+            );
+        }
+
+        this._frameQueue.push(buffer);
+        this._lastFrame = { buffer, timestamp };
+    }
+
+    /**
+     * Send queued frames over to ffmpeg
+     */
+    async _sendFrames() {
+        const frames = this._frameQueue;
+
+        while (frames.length) {
+            const frame = frames.shift();
+
+            await new Promise((resolve, reject) => {
+                this._process.stdin.write(frame, err => {
+                    err ? reject(err) : resolve();
+                });
+            });
+        }
+    }
+
+    async stop() {
+        assert(this._process);
+        if (!this._page.isClosed()) {
+            await this._session.send('Page.stopScreencast');
+        }
+        this._session.off('Page.screencastFrame', this._onFrame);
+
+        // Flush remaining frames up until the current time
+        this._writeFrame(
+            Buffer.from([]),
+            this._lastFrame.timestamp + (monotonicTime() - this._hrtime) / 1000
+        );
+        await this._sendFrames();
+        this._lastFrame = null;
+
+        await new Promise(r => this._process.stdin.end(r));
+        await this._closePromise;
+    }
+}
+
+module.exports = {
+    VideoRecorder,
+};

--- a/tests/selftest_video.js
+++ b/tests/selftest_video.js
@@ -1,0 +1,51 @@
+const assert = require('assert').strict;
+const path = require('path');
+const fs = require('fs').promises;
+const child_process = require('child_process');
+const { assertGreater } = require('../src/assert_utils');
+
+async function run() {
+    const sub_run = path.join(__dirname, 'video', 'run');
+    const { stdout } = await new Promise((resolve, reject) => {
+        child_process.execFile(
+            process.execPath,
+            [sub_run, '--exit-zero', '--no-screenshots', '-v', '--video'],
+            { cwd: path.dirname(sub_run) },
+            (err, stdout, stderr) => {
+                if (err) reject(err);
+                else resolve({ stdout, stderr });
+            }
+        );
+    });
+
+    /** @type {string[]} */
+    const videos = Array.from(stdout.matchAll(/Recording\svideo:\s(.*?)\s\[/gm))
+        .map(match => match[1])
+        .sort();
+
+    const isFile = f =>
+        fs
+            .lstat(f)
+            .then(f => f.isFile())
+            .catch(() => false);
+
+    try {
+        assert(await isFile(videos[0]), `${videos[0]} is not a file`);
+        assert(
+            !(await isFile(videos[1])),
+            `${videos[1]} is a file, but the test succeded`
+        );
+
+        // Check that the file has some frames
+        const size = await (await fs.lstat(videos[0])).size;
+        assertGreater(size, 5000);
+    } catch (err) {
+        console.log(stdout);
+        throw err;
+    }
+}
+
+module.exports = {
+    description: 'record a video of browser page',
+    run,
+};

--- a/tests/video/run
+++ b/tests/video/run
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+
+const pentf = require('../../src/index.js');
+
+pentf.main({
+    rootDir: __dirname,
+});

--- a/tests/video/video-fail.js
+++ b/tests/video/video-fail.js
@@ -1,0 +1,18 @@
+const { newPage } = require('../../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.goto('https://example.com', { waitUntil: ['networkidle0'] });
+
+    await Promise.all([
+        page.waitForNavigation({ waitUntil: 'networkidle0' }),
+        page.click('a'),
+    ]);
+
+    throw new Error('fail');
+}
+
+module.exports = {
+    description: 'Record a video of the page and fail',
+    run,
+};

--- a/tests/video/video-success.js
+++ b/tests/video/video-success.js
@@ -1,0 +1,16 @@
+const { newPage } = require('../../src/browser_utils');
+
+async function run(config) {
+    const page = await newPage(config);
+    await page.goto('https://example.com', { waitUntil: ['networkidle0'] });
+
+    await Promise.all([
+        page.waitForNavigation({ waitUntil: 'networkidle0' }),
+        page.click('a'),
+    ]);
+}
+
+module.exports = {
+    description: 'Record a video of the page',
+    run,
+};


### PR DESCRIPTION
This PR attempts to add video recording capabilities to `pentf`. It leverages the experimental devtools [Screencast API](https://chromedevtools.github.io/devtools-protocol/tot/Page/#method-startScreencast), which despite its experimental state seems to work flawlessly.

Todos:

- [ ] Properly detect `ffmpeg` on the system across different OSes
- [x] Wire up video recorder into internals and expose via `--video` (name to be decided)
- [x] Where should we store the output file?