### PR TITLE
Fix page being closed in middle of teardown hooks

### DIFF
--- a/src/runner.js
+++ b/src/runner.js
@@ -235,10 +235,13 @@ async function run_task(config, state, task) {
                 `[runner] Executing ${task_config._teardown_hooks.length} teardown hooks`
             );
             try {
-                // Run teardown functions if there are any
-                const teardownPromise = Promise.all(
-                    task_config._teardown_hooks.map(fn => fn(task_config))
-                );
+                // Run teardown functions in sequence if there are any
+                const teardownPromise = (async () => {
+                    for (const fn of task_config._teardown_hooks) {
+                        await fn(task_config);
+                    }
+                })();
+
                 await timeoutPromise(config, teardownPromise, {
                     timeout: 30000,
                     message: 'teardown took too long',

--- a/tests/selftest_teardown_sequence.js
+++ b/tests/selftest_teardown_sequence.js
@@ -1,0 +1,36 @@
+const assert = require('assert').strict;
+const runner = require('../src/runner');
+const { wait } = require('../src/utils');
+
+/**
+ * @param {import('../src/runner').TaskConfig} config
+ * @param {string[]} output
+ * @param {number} ms
+ * @param {string} name
+ */
+function effect(config, output, ms, name) {
+    runner.onTeardown(config, async () => {
+        await wait(ms);
+        output.push(name);
+    });
+}
+
+async function run(config) {
+    let output = [];
+    await runner.run({ ...config, logFunc: () => null, quiet: true }, [
+        {
+            name: 'normal teardown',
+            run: async config => {
+                effect(config, output, 100, 'A');
+                effect(config, output, 200, 'B');
+                effect(config, output, 0, 'C');
+            },
+        },
+    ]);
+    assert.deepEqual(output, ['A', 'B', 'C']);
+}
+
+module.exports = {
+    run,
+    description: 'Teardown hooks must be called in sequence',
+};


### PR DESCRIPTION
To avoid the page being closed prematurely by one of the teadown hooks,
we need to run them in sequence.