### PR TITLE
assertAccessibility: improve screenshot error handling

### DIFF
--- a/src/browser_utils.js
+++ b/src/browser_utils.js
@@ -2163,9 +2163,11 @@ async function assertAccessibility(config, page) {
                     } catch (err) {
                         output.logVerbose(
                             config,
-                            '[runner] Could not take screenshot ' + err.message
+                            `[a11y] Could not take screenshot with selector ${selector}: ${err.message}`
                         );
-                        return null;
+                        // try again without selector:
+                        const img = await takeScreenshot(config, page, name);
+                        imgs.push(img);
                     }
                 }
             }


### PR DESCRIPTION
If taking a screenshot fails, avoid swallowing all errors.

First try again to take the screenshot without the selector. Not super useful, but better than nothing.

Also drop the `return null` - if taking the screenshot without the selector also fails, let the whole thing fail, so we can fix it properly.