### PR TITLE
Make puppeteer dependency optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,11 @@
   "peerDependencies": {
     "puppeteer": "*"
   },
+  "peerDependenciesMeta": {
+    "puppeteer": {
+      "optional": true
+    }
+  },
   "scripts": {
     "test": "./run",
     "lint": "eslint . run",


### PR DESCRIPTION
Do not require puppeteer for client projects; some backend-only projects work fine without needing the huge download.
