### PR TITLE
curl_command: Fix & test handling of URLSearchParams

### DIFF
--- a/src/curl_command.js
+++ b/src/curl_command.js
@@ -68,6 +68,12 @@ async function makeCurlCommand(options, url) {
         } else if (Buffer.isBuffer(options.body)) {
             const body_b64 = options.body.toString('base64');
             curl_command = add_binary_data(curl_command, body_b64);
+        } else if (options.body instanceof URLSearchParams) {
+            if (!headers['Content-Type']) {
+                curl_command +=
+                    ' -H "Content-Type: application/x-www-form-urlencoded"';
+            }
+            curl_command += ` -d ${options.body.toString()}`;
         } else if (/\0/.test(options.body)) {
             const body_b64 = Buffer.from(options.body).toString('base64');
             curl_command = add_binary_data(curl_command, body_b64);

--- a/tests/selftest_curl_command.js
+++ b/tests/selftest_curl_command.js
@@ -1,0 +1,43 @@
+const assert = require('assert').strict;
+
+const { promisify } = require('util');
+const tough = require('tough-cookie');
+const { makeCurlCommand } = require('../src/curl_command');
+
+async function run() {
+    const cookieJar = new tough.CookieJar();
+    const setCookieFunc = promisify((cookie, url, callback) =>
+        cookieJar.setCookie(cookie, url, {}, callback)
+    );
+    await setCookieFunc('foo=bar', 'https://example.com/');
+    await setCookieFunc('bar="baz \'\\123"', 'https://example.com/');
+
+    const params = new URLSearchParams();
+    params.append('foo', 'bar');
+    params.append('chars', 'ä€"\\\'');
+    params.append('foo', 'baz');
+
+    const curlCommand = await makeCurlCommand(
+        {
+            cookieJar,
+            headers: {
+                Referer: 'https://example.com/from?x=1',
+                'X-Strange-Chars': '"\'\\',
+            },
+            body: params,
+        },
+        'https://example.com/target?x=2'
+    );
+    assert.equal(
+        curlCommand,
+        `curl -H 'Referer: https://example.com/from?x=1' -H 'X-Strange-Chars: "'"'"'\\'` +
+            ` -H Expect: -H "Content-Type: application/x-www-form-urlencoded"` +
+            ` -d foo=bar&chars=%C3%A4%E2%82%AC%22%5C%27&foo=baz 'https://example.com/target?x=2'`
+    );
+}
+
+module.exports = {
+    description:
+        '-c / --print-curl option net_utils.fetch, namely cookie handling',
+    run,
+};


### PR DESCRIPTION
Make sure `-c` works when the body is a `URLSearchParams` instance.

While we're at it, also fix some related cookie handling, make sure we await setting the cookies.
