### PR TITLE
email: Correct timeout handling & fix self-tests

### DIFF
--- a/tests/selftest_email_socket_timeout.js
+++ b/tests/selftest_email_socket_timeout.js
@@ -61,8 +61,9 @@ async function run() {
     };
 
     // A short timeout will be triggered immediately
-    // Note that socket_timeout the *minimal* timeout, emailjs adds some ms more per byte
+    // Note that socket_timeout is the *minimal* timeout, emailjs adds some ms more per byte
     pseudoConfig.imap.socket_timeout = 1;
+
     await assert.rejects(
         connect(pseudoConfig, 'foo@example.org'),
         { message: ' Socket timed out!' } // yes, with a space in front


### PR DESCRIPTION
Make sure to always listen to out-of-band errors and throw them immediately on the promise (instead of separately, terminating the process).
