### PR TITLE
email: Fix logic of matching To header (TOC-5845)

### DIFF
--- a/src/email.js
+++ b/src/email.js
@@ -99,7 +99,7 @@ async function _find_message(config, client, since, to, subjectContains) {
         }
 
         const header_to = parseHeader('To', msg['body[header.fields (to)]']);
-        if (header_to.toLowerCase().includes(targetTo)) {
+        if (!header_to.toLowerCase().includes(targetTo)) {
             continue;
         }
 


### PR DESCRIPTION
We want to _skip_ if the email does *not* match.
We'll definitely look into setting up an e2etest with a local IMAP server to be able to self-test this!
