### PR TITLE
workflow: Run apt-get update before using apt

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,7 @@ jobs:
       - name: Linux test
         if: matrix.os == 'ubuntu-latest'
         run: |
+            sudo apt-get update
             sudo apt-get install ffmpeg
             xvfb-run --auto-servernum ./run --ci
 


### PR DESCRIPTION
This is required if the container is a bit older.
