### PR TITLE
Add experimental support for native fetch

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,7 +9,8 @@
     "plugins": ["prettier"],
     "globals": {
         "Atomics": "readonly",
-        "SharedArrayBuffer": "readonly"
+        "SharedArrayBuffer": "readonly",
+        "globalThis": "readonly"
     },
     "parserOptions": {
         "ecmaVersion": 2020


### PR DESCRIPTION
Add experimental support for node.js's built-in native `fetch`.

It's severely limited right now, in particular won't accept self-signed certificates, but is interesting for its performance implications.