### PR TITLE
email: Add new magic value __to_account__

### DIFF
--- a/src/email.js
+++ b/src/email.js
@@ -166,6 +166,16 @@ async function connect(config, user) {
     return client;
 }
 
+function resolveUser(config, to) {
+    const user = config.imap.user;
+    if (user === '__to__') {
+        return to;
+    } else if (user === '__to_account__') {
+        return to.replace(/\+[^@]+/, '');
+    }
+    return user;
+}
+
 /**
  * Retrieve and delete an email.
  *
@@ -200,10 +210,7 @@ async function getMail(
 
     assert(Array.isArray(wait_times));
 
-    let user = config.imap.user;
-    if (user === '__to__') {
-        user = to;
-    }
+    const user = resolveUser(config, to);
 
     let { email_cached_clients } = config;
     if (!email_cached_clients) {
@@ -288,4 +295,5 @@ module.exports = {
     parseBody,
     parseHeader,
     shutdown,
+    resolveUser,
 };

--- a/tests/selftest_email.js
+++ b/tests/selftest_email.js
@@ -1,6 +1,6 @@
 const assert = require('assert').strict;
 
-const { parseHeader } = require('../src/email');
+const { parseHeader, resolveUser } = require('../src/email');
 
 async function run() {
     assert.equal(parseHeader('To', 'To: somebody\r\n'), 'somebody');
@@ -19,6 +19,25 @@ async function run() {
             'To: integrationtests+api2_invitation_owner3mmx1hxg467@boxine.de\r\n abc\r\n abc\r\n'
         ),
         'integrationtests+api2_invitation_owner3mmx1hxg467@boxine.de abc abc'
+    );
+
+    assert.equal(
+        resolveUser(
+            { imap: { user: 'foo+a@bar.example' } },
+            'somebody+123@mail.com'
+        ),
+        'foo+a@bar.example'
+    );
+    assert.equal(
+        resolveUser({ imap: { user: '__to__' } }, 'somebody+123@mail.com'),
+        'somebody+123@mail.com'
+    );
+    assert.equal(
+        resolveUser(
+            { imap: { user: '__to_account__' } },
+            'somebody+123@mail.com'
+        ),
+        'somebody@mail.com'
     );
 }
 

--- a/tests/selftest_getMail.js
+++ b/tests/selftest_getMail.js
@@ -85,13 +85,22 @@ const PSEUDO_EMAILS = [
         'body[header.fields (to)]': 'To: foo@bar.example\r\n\r\n',
         _message: 'msg 5',
     },
+    {
+        '#': 6,
+        uid: 5000006,
+        'body[header.fields (subject)]': 'Subject: Number 6 with plus\r\n\r\n',
+        'body[header.fields (date)]':
+            'Date: Thu, 31 Aug 2023 16:06:00 +0000\r\n\r\n',
+        'body[header.fields (to)]': 'To: foo+test123@bar.example\r\n\r\n',
+        _message: 'msg 6 (with plus)',
+    },
 ];
 
 async function run() {
     const client = new PseudoEmailClient();
     const pseudoConfig = {
         imap: {
-            user: 'foo@bar.example',
+            user: '__to_account__',
         },
         keep_emails: true,
         email_cached_clients: new Map([['foo@bar.example', client]]),
@@ -106,6 +115,15 @@ async function run() {
         [1]
     );
     assert.equal(firstMail.text, 'msg 5');
+
+    const plusMail = await getMail(
+        pseudoConfig,
+        since,
+        'foo+test123@bar.example',
+        'Number',
+        [1]
+    );
+    assert.equal(plusMail.text, 'msg 6 (with plus)');
 
     const matchedByFuncMail = await getMail(
         pseudoConfig,


### PR DESCRIPTION
Users can frequently receive emails at `joe.smith+test123@mail.com`. For some mailservices, this is a separate email address.
For others, it gets redirected to `joe.smith@mail.com`.

Support this with a new magic value; we need to due to the greenmail update.
