### PR TITLE
Add net_utils.findHTTPHeader

### DIFF
--- a/src/net_utils.js
+++ b/src/net_utils.js
@@ -217,7 +217,32 @@ async function setupTLSClientAuth(
     );
 }
 
+/**
+ * Find the name of an HTTP header (case-insensitively) in a JavaScript object.
+ *
+ * @example
+ * ```javascript
+ * findHTTPHeader({'User-agent': 'foo'}, 'User-Agent')  // Returns 'User-agent'
+ * findHTTPHeader({}, 'User-Agent')  // Returns undefined
+ * ```
+ * @param {Object} headers The HTTP headers
+ * @param {string} headerName The target header name, ideally already in lower-case
+ * @returns {string?} The name of the header
+ */
+function findHTTPHeader(headers, headerName) {
+    headerName = headerName.toLowerCase();
+
+    for (let hn in headers) {
+        if (hn.toLowerCase() === headerName) {
+            return hn;
+        }
+    }
+
+    return undefined;
+}
+
 module.exports = {
     fetch,
+    findHTTPHeader,
     setupTLSClientAuth,
 };

--- a/tests/selftest_findHTTPHeader.js
+++ b/tests/selftest_findHTTPHeader.js
@@ -1,0 +1,25 @@
+const assert = require('assert').strict;
+
+const { findHTTPHeader } = require('../src/net_utils');
+
+async function run() {
+    assert.equal(
+        findHTTPHeader(
+            {
+                Authorization: 'secret',
+                'User-agent': 'xx',
+            },
+            'User-Agent'
+        ),
+        'User-agent'
+    );
+
+    assert.equal(findHTTPHeader({}, 'User-Agent'), undefined);
+}
+
+module.exports = {
+    description:
+        'Test net_utils.findHTTPHeader for case-insensitive search in HTTP header specifications',
+    resources: [],
+    run,
+};


### PR DESCRIPTION
Add a helper function to find a key in a HTTP header object.

We use the old-fashioned way rather than `localCompare`, since we only deal with ASCII characters in HTTP header names, and don't want to construct `Intl.Collator` objects and the like.
